### PR TITLE
fix: Error messages truncated

### DIFF
--- a/src/app/configs/config-detail/config-detail.component.html
+++ b/src/app/configs/config-detail/config-detail.component.html
@@ -14,9 +14,9 @@
     @if (errorMessages.length > 0) {
       <mat-list>
         @for (item of errorMessages; track item) {
-          <mat-list-item>
-            <mat-icon color="warn" mat-list-icon>error</mat-icon>
-            {{ item }}
+          <mat-list-item class="error-messages-container">
+            <mat-icon color='warn' matListItemIcon>error</mat-icon>
+            <span class="error-messages" matListItemTitle>{{ item }}</span>
           </mat-list-item>
         }
       </mat-list>

--- a/src/app/configs/config-detail/config-detail.component.ts
+++ b/src/app/configs/config-detail/config-detail.component.ts
@@ -19,7 +19,7 @@ import { MatRadioGroup, MatRadioButton } from '@angular/material/radio'
 import { MatInput } from '@angular/material/input'
 import { MatFormField, MatError, MatHint } from '@angular/material/form-field'
 import { MatIcon } from '@angular/material/icon'
-import { MatList, MatListItem } from '@angular/material/list'
+import { MatList, MatListItem, MatListItemIcon, MatListItemTitle } from '@angular/material/list'
 import {
   MatCard,
   MatCardHeader,
@@ -55,7 +55,9 @@ import { MatToolbar } from '@angular/material/toolbar'
     MatRadioButton,
     MatSlideToggle,
     MatCardActions,
-    MatButton
+    MatButton,
+    MatListItemIcon,
+    MatListItemTitle
   ]
 })
 export class ConfigDetailComponent implements OnInit {

--- a/src/app/domains/domain-detail/domain-detail.component.html
+++ b/src/app/domains/domain-detail/domain-detail.component.html
@@ -14,9 +14,9 @@
     @if (errorMessages.length > 0) {
       <mat-list>
         @for (item of errorMessages; track item) {
-          <mat-list-item>
-            <mat-icon color="warn" mat-list-icon>error</mat-icon>
-            {{ item }}
+          <mat-list-item class="error-messages-container">
+            <mat-icon color='warn' matListItemIcon>error</mat-icon>
+            <span class="error-messages" matListItemTitle>{{ item }}</span>
           </mat-list-item>
         }
       </mat-list>

--- a/src/app/domains/domain-detail/domain-detail.component.ts
+++ b/src/app/domains/domain-detail/domain-detail.component.ts
@@ -16,7 +16,7 @@ import { MatButton, MatIconButton } from '@angular/material/button'
 import { MatInput } from '@angular/material/input'
 import { MatFormField, MatError, MatHint, MatSuffix } from '@angular/material/form-field'
 import { MatIcon } from '@angular/material/icon'
-import { MatList, MatListItem } from '@angular/material/list'
+import { MatList, MatListItem, MatListItemIcon, MatListItemTitle } from '@angular/material/list'
 import {
   MatCard,
   MatCardHeader,
@@ -52,7 +52,9 @@ import { MatToolbar } from '@angular/material/toolbar'
     MatIconButton,
     MatSuffix,
     MatTooltip,
-    MatCardActions
+    MatCardActions,
+    MatListItemIcon,
+    MatListItemTitle
   ]
 })
 export class DomainDetailComponent implements OnInit {

--- a/src/app/ieee8021x/ieee8021x-detail/ieee8021x-detail.component.html
+++ b/src/app/ieee8021x/ieee8021x-detail/ieee8021x-detail.component.html
@@ -12,9 +12,9 @@
     @if (errorMessages.length > 0) {
       <mat-list>
         @for (item of errorMessages; track item) {
-          <mat-list-item>
-            <mat-icon color='warn' mat-list-icon>error</mat-icon>
-            {{ item }}
+          <mat-list-item class="error-messages-container">
+            <mat-icon color='warn' matListItemIcon>error</mat-icon>
+            <span class="error-messages" matListItemTitle>{{ item }}</span>
           </mat-list-item>
         }
       </mat-list>

--- a/src/app/ieee8021x/ieee8021x-detail/ieee8021x-detail.component.ts
+++ b/src/app/ieee8021x/ieee8021x-detail/ieee8021x-detail.component.ts
@@ -27,7 +27,7 @@ import { MatInput } from '@angular/material/input'
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field'
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio'
 import { MatIcon } from '@angular/material/icon'
-import { MatList, MatListItem } from '@angular/material/list'
+import { MatList, MatListItem, MatListItemIcon, MatListItemTitle } from '@angular/material/list'
 import { MatCard, MatCardSubtitle, MatCardContent, MatCardActions } from '@angular/material/card'
 import { MatProgressBar } from '@angular/material/progress-bar'
 import { MatToolbar } from '@angular/material/toolbar'
@@ -57,7 +57,9 @@ import { IEEE8021xConfig } from 'src/models/models'
     MatSelect,
     MatOption,
     MatCardActions,
-    MatButton
+    MatButton,
+    MatListItemIcon,
+    MatListItemTitle
   ]
 })
 export class IEEE8021xDetailComponent implements OnInit {

--- a/src/app/profiles/profile-detail/profile-detail.component.html
+++ b/src/app/profiles/profile-detail/profile-detail.component.html
@@ -13,7 +13,7 @@
       @for (item of errorMessages; track item) {
       <mat-list-item class="error-messages-container">
         <mat-icon color='warn' matListItemIcon>error</mat-icon>
-        <span  class="error-messages" matListItemTitle>{{ item }}</span>
+        <span class="error-messages" matListItemTitle>{{ item }}</span>
       </mat-list-item>
       }
     </mat-list>

--- a/src/app/profiles/profile-detail/profile-detail.component.scss
+++ b/src/app/profiles/profile-detail/profile-detail.component.scss
@@ -59,12 +59,3 @@ fieldset {
   font-size: 75%;
   color: rgba(0, 0, 0, 0.54);
 }
-
-.error-messages-container.mdc-list-item {
-  height: auto;
-  padding: 10px 0;
-}
-
-.error-messages {
-  white-space: break-spaces;
-}

--- a/src/app/wireless/wireless-detail/wireless-detail.component.html
+++ b/src/app/wireless/wireless-detail/wireless-detail.component.html
@@ -8,9 +8,9 @@
     @if (errorMessages.length > 0) {
       <mat-list>
         @for (item of errorMessages; track item) {
-          <mat-list-item>
-            <mat-icon color="warn" mat-list-icon>error</mat-icon>
-            {{ item }}
+          <mat-list-item class="error-messages-container">
+            <mat-icon color='warn' matListItemIcon>error</mat-icon>
+            <span class="error-messages" matListItemTitle>{{ item }}</span>
           </mat-list-item>
         }
       </mat-list>

--- a/src/app/wireless/wireless-detail/wireless-detail.component.ts
+++ b/src/app/wireless/wireless-detail/wireless-detail.component.ts
@@ -19,7 +19,7 @@ import { MatSelect } from '@angular/material/select'
 import { MatInput } from '@angular/material/input'
 import { MatFormField, MatLabel, MatError, MatHint, MatSuffix } from '@angular/material/form-field'
 import { MatIcon } from '@angular/material/icon'
-import { MatList, MatListItem } from '@angular/material/list'
+import { MatList, MatListItem, MatListItemIcon, MatListItemTitle } from '@angular/material/list'
 import { MatCard, MatCardContent, MatCardActions } from '@angular/material/card'
 import { MatToolbar } from '@angular/material/toolbar'
 import { WirelessConfig } from 'src/models/models'
@@ -47,7 +47,9 @@ import { WirelessConfig } from 'src/models/models'
     MatSuffix,
     MatTooltip,
     MatCardActions,
-    MatButton
+    MatButton,
+    MatListItemIcon,
+    MatListItemTitle
   ]
 })
 export class WirelessDetailComponent implements OnInit {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -15,3 +15,12 @@ mat-sidenav-container {
 .mat-checkbox-inner-container {
   margin-top: 5px !important;
 }
+
+.error-messages-container.mat-mdc-list-item.mdc-list-item--with-leading-icon.mdc-list-item--with-one-line {
+  height: auto;
+  padding: 10px 0;
+}
+
+.error-messages.mdc-list-item__primary-text {
+  white-space: break-spaces;
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ N/A ] Unit Tests have been added for new changes
- [ N/A ] API tests have been updated if applicable
- [ N/A ] All commented code has been removed
- [ N/A ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

Before the fix, when adding any information in the tool, if validation or other errors occurred, the informational messages at the top were truncated. This fix ensures that the error messages are displayed in full, and it was estandardized in all the components that used this error messages.

Fixes #2527