### PR TITLE
fix: remove "Use CIRA" option from Add Device dialog

### DIFF
--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.html
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.html
@@ -70,49 +70,10 @@
       <mat-hint>{{ 'addDevice.enterTags.value' | translate }} </mat-hint>
     </mat-form-field>
 
-    <mat-checkbox
-      [(ngModel)]="useCIRA"
-      [ngModelOptions]="{ standalone: true }"
-      (change)="onCIRAChange($event.checked)"
-      class="flex flex-1">
-      {{ 'addDevice.useCIRA.value' | translate }}
-    </mat-checkbox>
-
-    @if (!useCIRA) {
-      <mat-checkbox formControlName="useTLS" class="flex flex-1">{{
-        'addDevice.useTLS.value' | translate
-      }}</mat-checkbox>
-      <mat-checkbox formControlName="allowSelfSigned" class="flex flex-1">{{
-        'addDevice.allowSelfSignedCertificates.value' | translate
-      }}</mat-checkbox>
-    }
-
-    @if (useCIRA) {
-      <mat-form-field appearance="fill" class="flex flex-1">
-        <mat-label>{{ 'addDevice.guid.value' | translate }}</mat-label>
-        <input matInput title="guid" formControlName="guid" />
-        <mat-hint>{{ 'addDevice.enterGuid.value' | translate }}</mat-hint>
-      </mat-form-field>
-
-      <mat-form-field appearance="fill" class="flex flex-1">
-        <mat-label>{{ 'addDevice.mpsPassword.value' | translate }}</mat-label>
-        <input
-          matInput
-          title="mpspassword"
-          formControlName="mpspassword"
-          type="password"
-          minlength="8"
-          maxlength="32" />
-        <mat-error>{{ 'fieldRequired.long.value' | translate }}</mat-error>
-        <mat-hint>{{ 'addDevice.mpsPasswordHint.value' | translate }}</mat-hint>
-      </mat-form-field>
-
-      <mat-form-field appearance="fill" class="flex flex-1">
-        <mat-label>{{ 'addDevice.mpsUsername.value' | translate }}</mat-label>
-        <input matInput title="mpsusername" formControlName="mpsusername" />
-        <mat-hint>{{ 'addDevice.mpsUsernameHint.value' | translate }}</mat-hint>
-      </mat-form-field>
-    }
+    <mat-checkbox formControlName="useTLS" class="flex flex-1">{{ 'addDevice.useTLS.value' | translate }}</mat-checkbox>
+    <mat-checkbox formControlName="allowSelfSigned" class="flex flex-1">{{
+      'addDevice.allowSelfSignedCertificates.value' | translate
+    }}</mat-checkbox>
 
     <button mat-raised-button color="primary" type="submit">{{ 'common.submit.value' | translate }}</button>
   </form>

--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
@@ -62,10 +62,7 @@ describe('AddDeviceEnterpriseComponent', () => {
       password: 'password',
       tenantId: '',
       useTLS: false,
-      allowSelfSigned: false,
-      guid: '',
-      mpsusername: 'admin',
-      mpspassword: ''
+      allowSelfSigned: false
     })
     component.submitForm()
 
@@ -77,7 +74,6 @@ describe('AddDeviceEnterpriseComponent', () => {
       tenantId: '',
       useTLS: false,
       allowSelfSigned: false,
-      guid: '',
       tags: ['']
     })
     expect(dialogCloseSpy).toHaveBeenCalledWith({ submitted: true })
@@ -91,151 +87,11 @@ describe('AddDeviceEnterpriseComponent', () => {
       password: '',
       tenantId: '',
       useTLS: false,
-      allowSelfSigned: false,
-      guid: '',
-      mpsusername: 'admin',
-      mpspassword: ''
+      allowSelfSigned: false
     })
     component.submitForm()
 
     expect(addDeviceSpy).not.toHaveBeenCalled()
     expect(dialogCloseSpy).not.toHaveBeenCalled()
-  })
-
-  it('should toggle CIRA fields visibility', () => {
-    expect(component.useCIRA).toBe(false)
-
-    component.onCIRAChange(true)
-    expect(component.useCIRA).toBe(true)
-
-    component.onCIRAChange(false)
-    expect(component.useCIRA).toBe(false)
-  })
-
-  it('should reset MPS fields but preserve guid when CIRA is disabled', () => {
-    component.form.patchValue({
-      guid: 'test-guid-123',
-      mpsusername: 'customUser'
-    })
-
-    component.onCIRAChange(false)
-
-    expect(component.form.get('guid')?.value).toBe('test-guid-123')
-    expect(component.form.get('mpsusername')?.value).toBe('admin')
-  })
-
-  it('should include guid and mpsusername as admin in submitted CIRA device', () => {
-    component.form.setValue({
-      hostname: 'example.com',
-      friendlyName: 'Test Device',
-      username: 'testuser',
-      password: 'password',
-      tenantId: '',
-      useTLS: false,
-      allowSelfSigned: false,
-      guid: 'test-guid-123',
-      mpsusername: 'customUser',
-      mpspassword: ''
-    })
-    component.useCIRA = true
-    component.submitForm()
-
-    const submittedDevice = addDeviceSpy.calls.mostRecent().args[0]
-    expect(submittedDevice.guid).toBe('test-guid-123')
-    expect(submittedDevice.mpsusername).toBe('admin')
-    expect(dialogCloseSpy).toHaveBeenCalledWith({ submitted: true })
-  })
-
-  it('should disable TLS options and username when CIRA is enabled', () => {
-    component.onCIRAChange(true)
-
-    expect(component.form.get('useTLS')?.disabled).toBe(true)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(true)
-    expect(component.form.get('username')?.disabled).toBe(true)
-    expect(component.form.get('useTLS')?.value).toBe(false)
-    expect(component.form.get('allowSelfSigned')?.value).toBe(false)
-    expect(component.form.get('username')?.value).toBe('admin')
-  })
-
-  it('should enable TLS options and username when CIRA is disabled', () => {
-    component.onCIRAChange(true)
-    component.onCIRAChange(false)
-
-    expect(component.form.get('useTLS')?.disabled).toBe(false)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(false)
-    expect(component.form.get('username')?.disabled).toBe(false)
-  })
-
-  it('should set useCIRA when device has mpsusername', () => {
-    // This is tested via constructor behavior with MAT_DIALOG_DATA
-    // Mocking would require a different test setup
-    expect(component).toBeTruthy()
-  })
-})
-
-describe('AddDeviceEnterpriseComponent with CIRA device', () => {
-  let component: AddDeviceEnterpriseComponent
-  let fixture: ComponentFixture<AddDeviceEnterpriseComponent>
-
-  beforeEach(() => {
-    const deviceService = jasmine.createSpyObj('DevicesService', ['addDevice', 'editDevice'])
-    deviceService.addDevice.and.returnValue(of({}))
-    deviceService.editDevice.and.returnValue(of({}))
-
-    TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatDialogModule,
-        MatCheckboxModule,
-        MatInputModule,
-        MatFormFieldModule,
-        FormsModule,
-        ReactiveFormsModule,
-        MatChipsModule,
-        AddDeviceEnterpriseComponent,
-        TranslateModule.forRoot()
-      ],
-      providers: [
-        { provide: DevicesService, useValue: deviceService },
-        {
-          provide: MAT_DIALOG_DATA,
-          useValue: {
-            hostname: 'test-device.local',
-            friendlyName: 'Test CIRA Device',
-            username: 'admin',
-            password: 'testpass',
-            guid: 'test-guid-123',
-            mpsusername: 'admin',
-            tags: ['cira']
-          }
-        },
-        {
-          provide: MatDialogRef,
-          useValue: {
-            close: () => {
-              /* empty */
-            }
-          }
-        }
-      ]
-    })
-    fixture = TestBed.createComponent(AddDeviceEnterpriseComponent)
-    component = fixture.componentInstance
-    fixture.detectChanges()
-  })
-
-  it('should enable CIRA mode when device has mpsusername populated', () => {
-    expect(component.useCIRA).toBe(true)
-  })
-
-  it('should disable TLS and username fields when CIRA device is loaded', () => {
-    expect(component.form.get('useTLS')?.disabled).toBe(true)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(true)
-    expect(component.form.get('username')?.disabled).toBe(true)
-    expect(component.form.get('mpsusername')?.disabled).toBe(true)
-  })
-
-  it('should preserve guid value for CIRA device', () => {
-    expect(component.form.get('guid')?.value).toBe('test-guid-123')
   })
 })

--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.spec.ts
@@ -62,10 +62,7 @@ describe('AddDeviceEnterpriseComponent', () => {
       password: 'password',
       tenantId: '',
       useTLS: false,
-      allowSelfSigned: false,
-      guid: '',
-      mpsusername: 'admin',
-      mpspassword: ''
+      allowSelfSigned: false
     })
     component.submitForm()
 
@@ -77,7 +74,6 @@ describe('AddDeviceEnterpriseComponent', () => {
       tenantId: '',
       useTLS: false,
       allowSelfSigned: false,
-      guid: '',
       tags: ['']
     })
     expect(dialogCloseSpy).toHaveBeenCalledWith({ submitted: true })
@@ -91,151 +87,11 @@ describe('AddDeviceEnterpriseComponent', () => {
       password: '',
       tenantId: '',
       useTLS: false,
-      allowSelfSigned: false,
-      guid: '',
-      mpsusername: 'admin',
-      mpspassword: ''
+      allowSelfSigned: false
     })
     component.submitForm()
 
     expect(addDeviceSpy).not.toHaveBeenCalled()
     expect(dialogCloseSpy).not.toHaveBeenCalled()
-  })
-
-  it('should toggle CIRA fields visibility', () => {
-    expect(component.useCIRA).toBe(false)
-
-    component.onCIRAChange(true)
-    expect(component.useCIRA).toBe(true)
-
-    component.onCIRAChange(false)
-    expect(component.useCIRA).toBe(false)
-  })
-
-  it('should reset MPS fields but preserve guid when CIRA is disabled', () => {
-    component.form.patchValue({
-      guid: 'test-guid-123',
-      mpsusername: 'customUser'
-    })
-
-    component.onCIRAChange(false)
-
-    expect(component.form.get('guid')?.value).toBe('test-guid-123')
-    expect(component.form.get('mpsusername')?.value).toBe('admin')
-  })
-
-  it('should include guid and mpsusername as admin in submitted CIRA device', () => {
-    component.form.setValue({
-      hostname: 'example.com',
-      friendlyName: 'Test Device',
-      username: 'testuser',
-      password: 'password',
-      tenantId: '',
-      useTLS: false,
-      allowSelfSigned: false,
-      guid: 'test-guid-123',
-      mpsusername: 'customUser',
-      mpspassword: ''
-    })
-    component.useCIRA = true
-    component.submitForm()
-
-    const submittedDevice = addDeviceSpy.calls.mostRecent().args[0]
-    expect(submittedDevice.guid).toBe('test-guid-123')
-    expect(submittedDevice.mpsusername).toBe('admin')
-    expect(dialogCloseSpy).toHaveBeenCalledWith({ submitted: true })
-  })
-
-  it('should disable TLS options and username when CIRA is enabled', () => {
-    component.onCIRAChange(true)
-
-    expect(component.form.get('useTLS')?.disabled).toBe(true)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(true)
-    expect(component.form.get('username')?.disabled).toBe(true)
-    expect(component.form.get('useTLS')?.value).toBe(false)
-    expect(component.form.get('allowSelfSigned')?.value).toBe(false)
-    expect(component.form.get('username')?.value).toBe('admin')
-  })
-
-  it('should enable TLS options and username when CIRA is disabled', () => {
-    component.onCIRAChange(true)
-    component.onCIRAChange(false)
-
-    expect(component.form.get('useTLS')?.disabled).toBe(false)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(false)
-    expect(component.form.get('username')?.disabled).toBe(false)
-  })
-
-  it('should set useCIRA when device has mpsusername', () => {
-    // This is tested via constructor behavior with MAT_DIALOG_DATA
-    // Mocking would require a different test setup
-    expect(component).toBeTruthy()
-  })
-})
-
-describe('AddDeviceEnterpriseComponent with CIRA device', () => {
-  let component: AddDeviceEnterpriseComponent
-  let fixture: ComponentFixture<AddDeviceEnterpriseComponent>
-
-  beforeEach(() => {
-    const deviceService = jasmine.createSpyObj('DevicesService', ['addDevice', 'editDevice'])
-    deviceService.addDevice.and.returnValue(of({}))
-    deviceService.editDevice.and.returnValue(of({}))
-
-    TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        MatDialogModule,
-        MatCheckboxModule,
-        MatInputModule,
-        MatFormFieldModule,
-        FormsModule,
-        ReactiveFormsModule,
-        MatChipsModule,
-        AddDeviceEnterpriseComponent
-      ],
-      providers: [
-        provideTranslateService(),
-        { provide: DevicesService, useValue: deviceService },
-        {
-          provide: MAT_DIALOG_DATA,
-          useValue: {
-            hostname: 'test-device.local',
-            friendlyName: 'Test CIRA Device',
-            username: 'admin',
-            password: 'testpass',
-            guid: 'test-guid-123',
-            mpsusername: 'admin',
-            tags: ['cira']
-          }
-        },
-        {
-          provide: MatDialogRef,
-          useValue: {
-            close: () => {
-              /* empty */
-            }
-          }
-        }
-      ]
-    })
-    fixture = TestBed.createComponent(AddDeviceEnterpriseComponent)
-    component = fixture.componentInstance
-    fixture.detectChanges()
-  })
-
-  it('should enable CIRA mode when device has mpsusername populated', () => {
-    expect(component.useCIRA).toBe(true)
-  })
-
-  it('should disable TLS and username fields when CIRA device is loaded', () => {
-    expect(component.form.get('useTLS')?.disabled).toBe(true)
-    expect(component.form.get('allowSelfSigned')?.disabled).toBe(true)
-    expect(component.form.get('username')?.disabled).toBe(true)
-    expect(component.form.get('mpsusername')?.disabled).toBe(true)
-  })
-
-  it('should preserve guid value for CIRA device', () => {
-    expect(component.form.get('guid')?.value).toBe('test-guid-123')
   })
 })

--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
@@ -5,7 +5,7 @@
 
 import { COMMA, ENTER } from '@angular/cdk/keycodes'
 import { Component, inject } from '@angular/core'
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms'
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms'
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips'
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogTitle, MatDialogContent } from '@angular/material/dialog'
 import { DevicesService } from '../../devices/devices.service'
@@ -27,7 +27,6 @@ import { TranslateModule } from '@ngx-translate/core'
     CdkScrollable,
     MatDialogContent,
     ReactiveFormsModule,
-    FormsModule,
     MatFormField,
     MatLabel,
     MatIcon,
@@ -61,14 +60,10 @@ export class AddDeviceEnterpriseComponent {
     password: ['', [Validators.required, Validators.minLength(8)]],
     tenantId: [''],
     useTLS: [false],
-    allowSelfSigned: [false],
-    guid: [''],
-    mpsusername: ['admin'],
-    mpspassword: ['', [Validators.minLength(8)]]
+    allowSelfSigned: [false]
   })
   public readonly separatorKeysCodes: number[] = [ENTER, COMMA]
   public tags: string[] = []
-  public useCIRA = false
 
   constructor() {
     const device = this.device
@@ -76,18 +71,8 @@ export class AddDeviceEnterpriseComponent {
     this.deviceOrig = device
     if (device != null) {
       this.tags = device.tags || []
-      // If device has mpsusername set, it's a CIRA device
-      if (device.mpsusername != null && device.mpsusername !== '') {
-        this.useCIRA = true
-      }
+      this.form.patchValue(device)
     }
-    this.form.patchValue(device)
-    // Ensure mpsusername defaults to admin if empty
-    if (!this.form.get('mpsusername')?.value) {
-      this.form.patchValue({ mpsusername: 'admin' })
-    }
-    // Apply CIRA state after patching form
-    this.onCIRAChange(this.useCIRA)
   }
 
   add(event: MatChipInputEvent): void {
@@ -107,48 +92,12 @@ export class AddDeviceEnterpriseComponent {
     }
   }
 
-  onCIRAChange(checked: boolean): void {
-    this.useCIRA = checked
-    if (checked) {
-      // CIRA mode: set values first, then disable controls
-      this.form.patchValue({
-        useTLS: false,
-        allowSelfSigned: false,
-        username: 'admin',
-        mpsusername: 'admin'
-      })
-      this.form.controls['useTLS'].disable()
-      this.form.controls['allowSelfSigned'].disable()
-      this.form.controls['username'].disable()
-      this.form.controls['mpsusername'].disable()
-    } else {
-      // Non-CIRA mode: enable controls first, then set values
-      this.form.controls['useTLS'].enable()
-      this.form.controls['allowSelfSigned'].enable()
-      this.form.controls['username'].enable()
-      this.form.controls['mpsusername'].enable()
-      this.form.patchValue({
-        mpsusername: 'admin',
-        mpspassword: ''
-      })
-    }
-  }
-
-  // Method to submit form
   submitForm(): void {
     if (this.form.valid) {
       const device: Device = { ...this.form.getRawValue() }
       device.tags = this.tags
-      if (this.useCIRA) {
-        // Ensure mpsusername is set to admin for CIRA devices
-        ;(device as any).mpsusername = 'admin'
-      } else {
-        // Remove CIRA fields when not using CIRA
-        delete (device as any).mpsusername
-        delete (device as any).mpspassword
-      }
       if (this.deviceOrig?.guid != null && this.deviceOrig?.guid !== '') {
-        // Use form's GUID value, don't overwrite with original
+        device.guid = this.deviceOrig.guid
         this.deviceService.editDevice(device).subscribe(() => {
           this.dialog.close({ submitted: true })
         })

--- a/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
+++ b/src/app/shared/add-device-enterprise/add-device-enterprise.component.ts
@@ -5,7 +5,7 @@
 
 import { COMMA, ENTER } from '@angular/cdk/keycodes'
 import { Component, inject } from '@angular/core'
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms'
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms'
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips'
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogTitle, MatDialogContent } from '@angular/material/dialog'
 import { DevicesService } from '../../devices/devices.service'
@@ -27,7 +27,6 @@ import { TranslatePipe } from '@ngx-translate/core'
     CdkScrollable,
     MatDialogContent,
     ReactiveFormsModule,
-    FormsModule,
     MatFormField,
     MatLabel,
     MatIcon,
@@ -61,14 +60,10 @@ export class AddDeviceEnterpriseComponent {
     password: ['', [Validators.required, Validators.minLength(8)]],
     tenantId: [''],
     useTLS: [false],
-    allowSelfSigned: [false],
-    guid: [''],
-    mpsusername: ['admin'],
-    mpspassword: ['', [Validators.minLength(8)]]
+    allowSelfSigned: [false]
   })
   public readonly separatorKeysCodes: number[] = [ENTER, COMMA]
   public tags: string[] = []
-  public useCIRA = false
 
   constructor() {
     const device = this.device
@@ -76,18 +71,8 @@ export class AddDeviceEnterpriseComponent {
     this.deviceOrig = device
     if (device != null) {
       this.tags = device.tags || []
-      // If device has mpsusername set, it's a CIRA device
-      if (device.mpsusername != null && device.mpsusername !== '') {
-        this.useCIRA = true
-      }
+      this.form.patchValue(device)
     }
-    this.form.patchValue(device)
-    // Ensure mpsusername defaults to admin if empty
-    if (!this.form.get('mpsusername')?.value) {
-      this.form.patchValue({ mpsusername: 'admin' })
-    }
-    // Apply CIRA state after patching form
-    this.onCIRAChange(this.useCIRA)
   }
 
   add(event: MatChipInputEvent): void {
@@ -107,48 +92,12 @@ export class AddDeviceEnterpriseComponent {
     }
   }
 
-  onCIRAChange(checked: boolean): void {
-    this.useCIRA = checked
-    if (checked) {
-      // CIRA mode: set values first, then disable controls
-      this.form.patchValue({
-        useTLS: false,
-        allowSelfSigned: false,
-        username: 'admin',
-        mpsusername: 'admin'
-      })
-      this.form.controls['useTLS'].disable()
-      this.form.controls['allowSelfSigned'].disable()
-      this.form.controls['username'].disable()
-      this.form.controls['mpsusername'].disable()
-    } else {
-      // Non-CIRA mode: enable controls first, then set values
-      this.form.controls['useTLS'].enable()
-      this.form.controls['allowSelfSigned'].enable()
-      this.form.controls['username'].enable()
-      this.form.controls['mpsusername'].enable()
-      this.form.patchValue({
-        mpsusername: 'admin',
-        mpspassword: ''
-      })
-    }
-  }
-
-  // Method to submit form
   submitForm(): void {
     if (this.form.valid) {
       const device: Device = { ...this.form.getRawValue() }
       device.tags = this.tags
-      if (this.useCIRA) {
-        // Ensure mpsusername is set to admin for CIRA devices
-        ;(device as any).mpsusername = 'admin'
-      } else {
-        // Remove CIRA fields when not using CIRA
-        delete (device as any).mpsusername
-        delete (device as any).mpspassword
-      }
       if (this.deviceOrig?.guid != null && this.deviceOrig?.guid !== '') {
-        // Use form's GUID value, don't overwrite with original
+        device.guid = this.deviceOrig.guid
         this.deviceService.editDevice(device).subscribe(() => {
           this.dialog.close({ submitted: true })
         })

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -123,34 +123,6 @@
     "description": "رسالة لاستخدام TLS",
     "value": "استخدم TLS"
   },
-  "addDevice.useCIRA": {
-    "description": "مربع اختيار لاستخدام اتصال CIRA",
-    "value": "استخدام CIRA"
-  },
-  "addDevice.guid": {
-    "description": "تسمية حقل GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "تلميح لإدخال GUID",
-    "value": "أدخل GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "تسمية حقل اسم مستخدم MPS",
-    "value": "اسم مستخدم MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "تلميح لحقل اسم مستخدم MPS",
-    "value": "اسم مستخدم MPS (افتراضي: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "تسمية حقل كلمة مرور MPS",
-    "value": "كلمة مرور MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "تلميح لحقل كلمة مرور MPS",
-    "value": "أدخل كلمة مرور MPS"
-  },
   "addDevice.amtPassword": {
     "description": "تسمية حقل كلمة مرور AMT",
     "value": "كلمة مرور AMT"

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -79,10 +79,6 @@
     "description": "وصف يشرح كيفية تنشيط الجهاز",
     "value": "لتنشيط جهاز، ستحتاج إلى تنفيذ أمر على جهاز AMT. سيساعدك مربع الحوار هذا في إنشاء الأمر المطلوب تنفيذه."
   },
-  "addDevice.enterGuid": {
-    "description": "تلميح لإدخال GUID",
-    "value": "أدخل GUID"
-  },
   "addDevice.enterTags": {
     "description": "تلميح لإدخال العلامات",
     "value": "يمكنك إدخال علامات للمساعدة في تنظيم الأجهزة والاستعلام عنها مع نمو قائمة الأجهزة المدارة. اكتب علامة، ثم اضغط على Enter أو ضع فاصلة."
@@ -95,10 +91,6 @@
     "description": "خطأ في الأسماء المطلوبة",
     "value": "الاسم المألوف مطلوب"
   },
-  "addDevice.guid": {
-    "description": "تسمية حقل GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "خطأ في أسماء المضيفين غير الصالحة",
     "value": "تنسيق اسم المضيف غير صالح"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "خطأ في أسماء المضيف المطلوبة",
     "value": "اسم المضيف مطلوب"
-  },
-  "addDevice.mpsPassword": {
-    "description": "تسمية حقل كلمة مرور MPS",
-    "value": "كلمة مرور MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "تلميح لحقل كلمة مرور MPS",
-    "value": "أدخل كلمة مرور MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "تسمية حقل اسم مستخدم MPS",
-    "value": "اسم مستخدم MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "تلميح لحقل اسم مستخدم MPS",
-    "value": "اسم مستخدم MPS (افتراضي: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "تسمية مربع الاختيار لتعطيل التحقق من الشهادة الموقعة ذاتيًا",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "عنوان مربع الحوار لإضافة جهاز جديد",
     "value": "إضافة جهاز جديد"
-  },
-  "addDevice.useCIRA": {
-    "description": "مربع اختيار لاستخدام اتصال CIRA",
-    "value": "استخدام CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "خطأ في اسم المستخدم غير صالح",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -123,34 +123,6 @@
     "description": "Hinweis zur Verwendung von TLS",
     "value": "Verwenden Sie TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Kontrollkästchen für die Verwendung der CIRA-Verbindung",
-    "value": "CIRA verwenden"
-  },
-  "addDevice.guid": {
-    "description": "Bezeichnung für das GUID-Feld",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Hinweis zur Eingabe der GUID",
-    "value": "GUID eingeben"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Bezeichnung für das MPS-Benutzername-Feld",
-    "value": "MPS-Benutzername"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hinweis für das MPS-Benutzername-Feld",
-    "value": "MPS-Benutzername (Standard: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Bezeichnung für das MPS-Passwort-Feld",
-    "value": "MPS-Passwort"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hinweis für das MPS-Passwort-Feld",
-    "value": "MPS-Passwort eingeben"
-  },
   "addDevice.amtPassword": {
     "description": "Bezeichnung für das AMT-Passwort-Feld",
     "value": "AMT-Passwort"

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -79,10 +79,6 @@
     "description": "Beschreibung zur Aktivierung eines Geräts",
     "value": "Um ein Gerät zu aktivieren, müssen Sie einen Befehl auf dem AMT-Gerät ausführen. Dieser Dialog hilft Ihnen bei der Generierung des auszuführenden Befehls."
   },
-  "addDevice.enterGuid": {
-    "description": "Hinweis zur Eingabe der GUID",
-    "value": "GUID eingeben"
-  },
   "addDevice.enterTags": {
     "description": "Hinweis zur Eingabe von Tags",
     "value": "Sie können Tags eingeben, um die Organisation und Abfrage von Geräten zu erleichtern, wenn Ihre Liste der verwalteten Geräte wächst. Geben Sie ein Tag ein und drücken Sie dann die Eingabetaste oder ein Komma."
@@ -95,10 +91,6 @@
     "description": "Fehler bei erforderlichen Anzeigenamen",
     "value": "Der Friendly Name ist erforderlich."
   },
-  "addDevice.guid": {
-    "description": "Bezeichnung für das GUID-Feld",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Fehler bei ungültigen Hostnamen",
     "value": "Ungültiges Hostnamenformat"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Fehler bei erforderlichen Hostnamen",
     "value": "Der Hostname ist erforderlich."
-  },
-  "addDevice.mpsPassword": {
-    "description": "Bezeichnung für das MPS-Passwort-Feld",
-    "value": "MPS-Passwort"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hinweis für das MPS-Passwort-Feld",
-    "value": "MPS-Passwort eingeben"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Bezeichnung für das MPS-Benutzername-Feld",
-    "value": "MPS-Benutzername"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hinweis für das MPS-Benutzername-Feld",
-    "value": "MPS-Benutzername (Standard: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Kontrollkästchen zum Deaktivieren der Überprüfung selbstsignierter Zertifikate",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Dialogtitel zum Hinzufügen eines neuen Geräts",
     "value": "Neues Gerät hinzufügen"
-  },
-  "addDevice.useCIRA": {
-    "description": "Kontrollkästchen für die Verwendung der CIRA-Verbindung",
-    "value": "CIRA verwenden"
   },
   "addDevice.userNameInvalid": {
     "description": "Fehler wegen ungültigem Benutzernamen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -271,34 +271,6 @@
     "description": "Message for using TLS",
     "value": "Use TLS"
   },
-  "addDevice.useCIRA": {
-    "description": "Checkbox label for using CIRA connection",
-    "value": "Use CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Label for GUID field",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Hint for entering GUID",
-    "value": "Enter GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Label for MPS Username field",
-    "value": "MPS Username"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hint for MPS Username field",
-    "value": "MPS Username (default: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Label for MPS Password field",
-    "value": "MPS Password"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hint for MPS Password field",
-    "value": "Enter MPS Password"
-  },
   "addDevice.amtPassword": {
     "description": "Label for AMT Password field",
     "value": "AMT Password"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -227,10 +227,6 @@
     "description": "Description explaining how to activate a device",
     "value": "In order to activate a device, you'll need to execute a command on the AMT Device. This dialog will help generate the command to run."
   },
-  "addDevice.enterGuid": {
-    "description": "Hint for entering GUID",
-    "value": "Enter GUID"
-  },
   "addDevice.enterTags": {
     "description": "Hint for entering tags",
     "value": "You can enter tags to help in organizing and querying devices as your list of managed devices grow. Type a tag, then present enter or comma."
@@ -243,10 +239,6 @@
     "description": "Error for required friendly names",
     "value": "Friendly Name is required"
   },
-  "addDevice.guid": {
-    "description": "Label for GUID field",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Error for invalid hostnames",
     "value": "Invalid hostname format"
@@ -254,22 +246,6 @@
   "addDevice.hostNameRequired": {
     "description": "Error for required hostnames",
     "value": "Hostname is required"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Label for MPS Password field",
-    "value": "MPS Password"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hint for MPS Password field",
-    "value": "Enter MPS Password"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Label for MPS Username field",
-    "value": "MPS Username"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hint for MPS Username field",
-    "value": "MPS Username (default: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Checkbox label to disable self-signed certificate check",
@@ -290,10 +266,6 @@
   "addDevice.title": {
     "description": "Dialog title for adding a new device",
     "value": "Add a New Device"
-  },
-  "addDevice.useCIRA": {
-    "description": "Checkbox label for using CIRA connection",
-    "value": "Use CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Error for invalid username",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -123,34 +123,6 @@
     "description": "Mensaje para el uso de TLS",
     "value": "Utilice TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Casilla de verificación para usar conexión CIRA",
-    "value": "Usar CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Etiqueta para el campo GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Sugerencia para ingresar GUID",
-    "value": "Ingrese GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etiqueta para el campo de nombre de usuario MPS",
-    "value": "Nombre de usuario MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Sugerencia para el campo de nombre de usuario MPS",
-    "value": "Nombre de usuario MPS (predeterminado: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Etiqueta para el campo de contraseña MPS",
-    "value": "Contraseña MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Sugerencia para el campo de contraseña MPS",
-    "value": "Introducir contraseña MPS"
-  },
   "addDevice.amtPassword": {
     "description": "Etiqueta para el campo de contraseña AMT",
     "value": "Contraseña AMT"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -79,10 +79,6 @@
     "description": "Descripción que explica cómo activar un dispositivo.",
     "value": "Para activar un dispositivo, deberá ejecutar un comando en el dispositivo AMT. Este cuadro de diálogo le ayudará a generar el comando que debe ejecutar."
   },
-  "addDevice.enterGuid": {
-    "description": "Sugerencia para ingresar GUID",
-    "value": "Ingrese GUID"
-  },
   "addDevice.enterTags": {
     "description": "Sugerencia para introducir etiquetas",
     "value": "Puede introducir etiquetas para ayudar a organizar y consultar los dispositivos a medida que crece su lista de dispositivos gestionados. Escriba una etiqueta y, a continuación, pulse Intro o una coma."
@@ -95,10 +91,6 @@
     "description": "Error en los nombres descriptivos obligatorios.",
     "value": "Se requiere un nombre descriptivo."
   },
-  "addDevice.guid": {
-    "description": "Etiqueta para el campo GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Error por nombres de host no válidos",
     "value": "Formato de nombre de host no válido."
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Error para los nombres de host requeridos",
     "value": "Se requiere el nombre de host."
-  },
-  "addDevice.mpsPassword": {
-    "description": "Etiqueta para el campo de contraseña MPS",
-    "value": "Contraseña MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Sugerencia para el campo de contraseña MPS",
-    "value": "Introducir contraseña MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etiqueta para el campo de nombre de usuario MPS",
-    "value": "Nombre de usuario MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Sugerencia para el campo de nombre de usuario MPS",
-    "value": "Nombre de usuario MPS (predeterminado: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Etiqueta de casilla de verificación para desactivar la comprobación de certificados autofirmados.",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Título del cuadro de diálogo para añadir un nuevo dispositivo",
     "value": "Añadir un nuevo dispositivo"
-  },
-  "addDevice.useCIRA": {
-    "description": "Casilla de verificación para usar conexión CIRA",
-    "value": "Usar CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Error por nombre de usuario no válido.",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -123,34 +123,6 @@
     "description": "Viesti TLS:n käytöstä",
     "value": "Käytä TLS:ää."
   },
-  "addDevice.useCIRA": {
-    "description": "Valintaruutu CIRA-yhteyden käyttöön",
-    "value": "Käytä CIRAa"
-  },
-  "addDevice.guid": {
-    "description": "GUID-kentän otsikko",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Vihje GUID:n syöttämiseen",
-    "value": "Syötä GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "MPS-käyttäjänimi-kentän otsikko",
-    "value": "MPS-käyttäjänimi"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Vihje MPS-käyttäjänimi-kenttään",
-    "value": "MPS-käyttäjänimi (oletus: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "MPS-salasana-kentän otsikko",
-    "value": "MPS-salasana"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Vihje MPS-salasana-kenttään",
-    "value": "Syötä MPS-salasana"
-  },
   "addDevice.amtPassword": {
     "description": "AMT-salasana-kentän otsikko",
     "value": "AMT-salasana"

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -79,10 +79,6 @@
     "description": "Kuvaus laitteen aktivoinnista",
     "value": "Laitteen aktivoimiseksi sinun on suoritettava komento AMT-laitteella. Tämä valintaikkuna auttaa luomaan suoritettavan komennon."
   },
-  "addDevice.enterGuid": {
-    "description": "Vihje GUID:n syöttämiseen",
-    "value": "Syötä GUID"
-  },
   "addDevice.enterTags": {
     "description": "Vinkki tagien syöttämiseen",
     "value": "Voit syöttää tunnisteita, jotka auttavat laitteiden järjestämisessä ja hakemisessa, kun hallinnoitujen laitteiden luettelo kasvaa. Kirjoita tunniste ja paina sitten Enter-näppäintä tai pilkkua."
@@ -95,10 +91,6 @@
     "description": "Virhe vaadituissa ystävällisissä nimissä",
     "value": "Ystävällinen nimi vaaditaan"
   },
-  "addDevice.guid": {
-    "description": "GUID-kentän otsikko",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Virhe kelpaamattomille isäntänimille",
     "value": "Virheellinen isäntänimen muoto"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Virhe vaadituissa isäntänimissä",
     "value": "Isäntänimi vaaditaan"
-  },
-  "addDevice.mpsPassword": {
-    "description": "MPS-salasana-kentän otsikko",
-    "value": "MPS-salasana"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Vihje MPS-salasana-kenttään",
-    "value": "Syötä MPS-salasana"
-  },
-  "addDevice.mpsUsername": {
-    "description": "MPS-käyttäjänimi-kentän otsikko",
-    "value": "MPS-käyttäjänimi"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Vihje MPS-käyttäjänimi-kenttään",
-    "value": "MPS-käyttäjänimi (oletus: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Valintaruutu, jolla voi poistaa itse allekirjoitetun varmenteen tarkistuksen käytöstä",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Uuden laitteen lisäämisen valintaikkunan otsikko",
     "value": "Lisää uusi laite"
-  },
-  "addDevice.useCIRA": {
-    "description": "Valintaruutu CIRA-yhteyden käyttöön",
-    "value": "Käytä CIRAa"
   },
   "addDevice.userNameInvalid": {
     "description": "Virhe kelpaamattomalle käyttäjätunnukselle",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -123,34 +123,6 @@
     "description": "Message pour l'utilisation de TLS",
     "value": "Utilisez TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Case à cocher pour utiliser la connexion CIRA",
-    "value": "Utiliser CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Étiquette pour le champ GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Indication pour entrer le GUID",
-    "value": "Entrez le GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Étiquette pour le champ nom d'utilisateur MPS",
-    "value": "Nom d'utilisateur MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Indication pour le champ nom d'utilisateur MPS",
-    "value": "Nom d'utilisateur MPS (par défaut: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Étiquette pour le champ mot de passe MPS",
-    "value": "Mot de passe MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Indication pour le champ mot de passe MPS",
-    "value": "Entrer le mot de passe MPS"
-  },
   "addDevice.amtPassword": {
     "description": "Étiquette pour le champ mot de passe AMT",
     "value": "Mot de passe AMT"

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -79,10 +79,6 @@
     "description": "Description expliquant comment activer un appareil",
     "value": "Afin d'activer un appareil, vous devrez exécuter une commande sur l'appareil AMT. Cette boîte de dialogue vous aidera à générer la commande à exécuter."
   },
-  "addDevice.enterGuid": {
-    "description": "Indication pour entrer le GUID",
-    "value": "Entrez le GUID"
-  },
   "addDevice.enterTags": {
     "description": "Conseil pour la saisie des balises",
     "value": "Vous pouvez saisir des balises pour faciliter l'organisation et la recherche des appareils à mesure que votre liste d'appareils gérés s'allonge. Saisissez une balise, puis appuyez sur Entrée ou ajoutez une virgule."
@@ -95,10 +91,6 @@
     "description": "Erreur pour les noms conviviaux requis",
     "value": "Le nom convivial est obligatoire."
   },
-  "addDevice.guid": {
-    "description": "Étiquette pour le champ GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Erreur pour les noms d'hôte non valides",
     "value": "Format de nom d'hôte non valide"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Erreur pour les noms d'hôte requis",
     "value": "Le nom d'hôte est obligatoire."
-  },
-  "addDevice.mpsPassword": {
-    "description": "Étiquette pour le champ mot de passe MPS",
-    "value": "Mot de passe MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Indication pour le champ mot de passe MPS",
-    "value": "Entrer le mot de passe MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Étiquette pour le champ nom d'utilisateur MPS",
-    "value": "Nom d'utilisateur MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Indication pour le champ nom d'utilisateur MPS",
-    "value": "Nom d'utilisateur MPS (par défaut: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Étiquette de case à cocher pour désactiver la vérification des certificats auto-signés",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Titre de la boîte de dialogue pour ajouter un nouvel appareil",
     "value": "Ajouter un nouvel appareil"
-  },
-  "addDevice.useCIRA": {
-    "description": "Case à cocher pour utiliser la connexion CIRA",
-    "value": "Utiliser CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Erreur pour nom d'utilisateur non valide",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -123,34 +123,6 @@
     "description": "הודעה לשימוש ב- TLS",
     "value": "השתמש ב- TLS"
   },
-  "addDevice.useCIRA": {
-    "description": "תיבת סימון לשימוש בחיבור CIRA",
-    "value": "השתמש ב-CIRA"
-  },
-  "addDevice.guid": {
-    "description": "תווית לשדה GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "רמז להזנת GUID",
-    "value": "הזן GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "תווית לשדה שם משתמש MPS",
-    "value": "שם משתמש MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "רמז לשדה שם משתמש MPS",
-    "value": "שם משתמש MPS (ברירת מחדל: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "תווית לשדה סיסמת MPS",
-    "value": "סיסמת MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "רמז לשדה סיסמת MPS",
-    "value": "הזן סיסמת MPS"
-  },
   "addDevice.amtPassword": {
     "description": "תווית לשדה סיסמת AMT",
     "value": "סיסמת AMT"

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -79,10 +79,6 @@
     "description": "תיאור מסביר כיצד להפעיל מכשיר",
     "value": "על מנת להפעיל מכשיר, תצטרך לבצע פקודה במכשיר AMT. "
   },
-  "addDevice.enterGuid": {
-    "description": "רמז להזנת GUID",
-    "value": "הזן GUID"
-  },
   "addDevice.enterTags": {
     "description": "רמז להיכנס לתגיות",
     "value": "אתה יכול להזין תגיות כדי לעזור בארגון ושאילתות מכשירי כאשר רשימת המכשירים המנוהלים שלך צומחת. "
@@ -95,10 +91,6 @@
     "description": "שגיאה לשמות ידידותיים נדרשים",
     "value": "נדרש שם ידידותי"
   },
-  "addDevice.guid": {
-    "description": "תווית לשדה GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "שגיאה עבור שמות מארח לא חוקיים",
     "value": "פורמט שם מארח לא חוקי"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "שגיאה עבור שמות מארח נדרשים",
     "value": "שם מארח נדרש"
-  },
-  "addDevice.mpsPassword": {
-    "description": "תווית לשדה סיסמת MPS",
-    "value": "סיסמת MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "רמז לשדה סיסמת MPS",
-    "value": "הזן סיסמת MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "תווית לשדה שם משתמש MPS",
-    "value": "שם משתמש MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "רמז לשדה שם משתמש MPS",
-    "value": "שם משתמש MPS (ברירת מחדל: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "תווית תיבת סימון כדי להשבית בדיקת אישור חתימה עצמית",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "כותרת דו -שיח להוספת מכשיר חדש",
     "value": "הוסף מכשיר חדש"
-  },
-  "addDevice.useCIRA": {
-    "description": "תיבת סימון לשימוש בחיבור CIRA",
-    "value": "השתמש ב-CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "שגיאה בשם משתמש לא חוקי",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -123,34 +123,6 @@
     "description": "Messaggio per l'utilizzo di TLS",
     "value": "Utilizzare TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Casella di controllo per utilizzare la connessione CIRA",
-    "value": "Usa CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Etichetta per il campo GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Suggerimento per inserire il GUID",
-    "value": "Inserisci GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etichetta per il campo nome utente MPS",
-    "value": "Nome utente MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Suggerimento per il campo nome utente MPS",
-    "value": "Nome utente MPS (predefinito: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Etichetta per il campo password MPS",
-    "value": "Password MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Suggerimento per il campo password MPS",
-    "value": "Inserire password MPS"
-  },
   "addDevice.amtPassword": {
     "description": "Etichetta per il campo password AMT",
     "value": "Password AMT"

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -79,10 +79,6 @@
     "description": "Descrizione che spiega come attivare un dispositivo",
     "value": "Per attivare un dispositivo, è necessario eseguire un comando sul dispositivo AMT. Questa finestra di dialogo aiuterà a generare il comando da eseguire."
   },
-  "addDevice.enterGuid": {
-    "description": "Suggerimento per inserire il GUID",
-    "value": "Inserisci GUID"
-  },
   "addDevice.enterTags": {
     "description": "Suggerimento per l'inserimento dei tag",
     "value": "È possibile inserire tag per facilitare l'organizzazione e la ricerca dei dispositivi man mano che l'elenco dei dispositivi gestiti cresce. Digitare un tag, quindi premere Invio o virgola."
@@ -95,10 +91,6 @@
     "description": "Errore per i nomi descrittivi richiesti",
     "value": "È richiesto il nome descrittivo."
   },
-  "addDevice.guid": {
-    "description": "Etichetta per il campo GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Errore per nomi host non validi",
     "value": "Formato del nome host non valido"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Errore per i nomi host richiesti",
     "value": "È richiesto il nome host."
-  },
-  "addDevice.mpsPassword": {
-    "description": "Etichetta per il campo password MPS",
-    "value": "Password MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Suggerimento per il campo password MPS",
-    "value": "Inserire password MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etichetta per il campo nome utente MPS",
-    "value": "Nome utente MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Suggerimento per il campo nome utente MPS",
-    "value": "Nome utente MPS (predefinito: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Etichetta della casella di controllo per disabilitare il controllo del certificato autofirmato.",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Titolo della finestra di dialogo per l'aggiunta di un nuovo dispositivo",
     "value": "Aggiungere un nuovo dispositivo"
-  },
-  "addDevice.useCIRA": {
-    "description": "Casella di controllo per utilizzare la connessione CIRA",
-    "value": "Usa CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Errore per nome utente non valido",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -123,34 +123,6 @@
     "description": "TLS ご利用に関するご案内",
     "value": "TLSを使用してください"
   },
-  "addDevice.useCIRA": {
-    "description": "CIRA接続を使用するチェックボックス",
-    "value": "CIRAを使用"
-  },
-  "addDevice.guid": {
-    "description": "GUIDフィールドのラベル",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "GUIDを入力するヒント",
-    "value": "GUIDを入力"
-  },
-  "addDevice.mpsUsername": {
-    "description": "MPSユーザー名フィールドのラベル",
-    "value": "MPSユーザー名"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "MPSユーザー名フィールドのヒント",
-    "value": "MPSユーザー名（デフォルト: admin）"
-  },
-  "addDevice.mpsPassword": {
-    "description": "MPSパスワードフィールドのラベル",
-    "value": "MPSパスワード"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "MPSパスワードフィールドのヒント",
-    "value": "MPSパスワードを入力"
-  },
   "addDevice.amtPassword": {
     "description": "AMTパスワードフィールドのラベル",
     "value": "AMTパスワード"

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -79,10 +79,6 @@
     "description": "デバイスのアクティベーション方法の説明",
     "value": "デバイスをアクティベートするには、AMTデバイス上でコマンドを実行する必要があります。このダイアログは、実行するコマンドを生成するのに役立ちます。"
   },
-  "addDevice.enterGuid": {
-    "description": "GUIDを入力するヒント",
-    "value": "GUIDを入力"
-  },
   "addDevice.enterTags": {
     "description": "タグ入力のヒント",
     "value": "管理対象デバイスが増加するにつれ、デバイスの整理や検索に役立つタグを入力できます。タグを入力後、Enterキーまたはコンマを入力してください。"
@@ -95,10 +91,6 @@
     "description": "必須のフレンドリーネームに関するエラー",
     "value": "フレンドリーネームは必須です"
   },
-  "addDevice.guid": {
-    "description": "GUIDフィールドのラベル",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "無効なホスト名に関するエラー",
     "value": "ホスト名の形式が無効です"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "必須ホスト名に関するエラー",
     "value": "ホスト名は必須です"
-  },
-  "addDevice.mpsPassword": {
-    "description": "MPSパスワードフィールドのラベル",
-    "value": "MPSパスワード"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "MPSパスワードフィールドのヒント",
-    "value": "MPSパスワードを入力"
-  },
-  "addDevice.mpsUsername": {
-    "description": "MPSユーザー名フィールドのラベル",
-    "value": "MPSユーザー名"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "MPSユーザー名フィールドのヒント",
-    "value": "MPSユーザー名（デフォルト: admin）"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "自己署名証明書のチェックを無効化するチェックボックスのラベル",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "新しいデバイスを追加するためのダイアログタイトル",
     "value": "新しいデバイスを追加する"
-  },
-  "addDevice.useCIRA": {
-    "description": "CIRA接続を使用するチェックボックス",
-    "value": "CIRAを使用"
   },
   "addDevice.userNameInvalid": {
     "description": "無効なユーザー名のためエラーが発生しました",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -123,34 +123,6 @@
     "description": "Bericht voor het gebruik van TLS",
     "value": "Gebruik TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Selectievakje voor het gebruik van CIRA-verbinding",
-    "value": "Gebruik CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Label voor het GUID-veld",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Hint voor het invoeren van GUID",
-    "value": "Voer GUID in"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Label voor het MPS-gebruikersnaam-veld",
-    "value": "MPS-gebruikersnaam"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hint voor het MPS-gebruikersnaam-veld",
-    "value": "MPS-gebruikersnaam (standaard: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Label voor het MPS-wachtwoord-veld",
-    "value": "MPS-wachtwoord"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hint voor het MPS-wachtwoord-veld",
-    "value": "Voer MPS-wachtwoord in"
-  },
   "addDevice.amtPassword": {
     "description": "Label voor het AMT-wachtwoord-veld",
     "value": "AMT-wachtwoord"

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -79,10 +79,6 @@
     "description": "Beschrijving waarin wordt uitgelegd hoe een apparaat kan worden geactiveerd.",
     "value": "Om een apparaat te activeren, dient u een opdracht uit te voeren op het AMT-apparaat. Dit dialoogvenster helpt u bij het genereren van de uit te voeren opdracht."
   },
-  "addDevice.enterGuid": {
-    "description": "Hint voor het invoeren van GUID",
-    "value": "Voer GUID in"
-  },
   "addDevice.enterTags": {
     "description": "Tip voor het invoeren van tags",
     "value": "U kunt tags invoeren om te helpen bij het organiseren en opvragen van apparaten naarmate uw lijst met beheerde apparaten groeit. Typ een tag en druk vervolgens op Enter of komma."
@@ -95,10 +91,6 @@
     "description": "Fout bij vereiste vriendelijke namen",
     "value": "Vriendelijke naam is vereist."
   },
-  "addDevice.guid": {
-    "description": "Label voor het GUID-veld",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Fout voor ongeldige hostnamen",
     "value": "Ongeldig hostnaamformaat"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Fout voor vereiste hostnamen",
     "value": "Hostnaam is vereist."
-  },
-  "addDevice.mpsPassword": {
-    "description": "Label voor het MPS-wachtwoord-veld",
-    "value": "MPS-wachtwoord"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Hint voor het MPS-wachtwoord-veld",
-    "value": "Voer MPS-wachtwoord in"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Label voor het MPS-gebruikersnaam-veld",
-    "value": "MPS-gebruikersnaam"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Hint voor het MPS-gebruikersnaam-veld",
-    "value": "MPS-gebruikersnaam (standaard: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Selectievakje om controle van zelfondertekende certificaten uit te schakelen",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Dialoogvenster voor het toevoegen van een nieuw apparaat",
     "value": "Een nieuw apparaat toevoegen"
-  },
-  "addDevice.useCIRA": {
-    "description": "Selectievakje voor het gebruik van CIRA-verbinding",
-    "value": "Gebruik CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Foutmelding voor ongeldige gebruikersnaam",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -123,34 +123,6 @@
     "description": "Сообщение об использовании TLS",
     "value": "Используйте TLS."
   },
-  "addDevice.useCIRA": {
-    "description": "Флажок для использования соединения CIRA",
-    "value": "Использовать CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Метка для поля GUID",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Подсказка для ввода GUID",
-    "value": "Введите GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Метка для поля имени пользователя MPS",
-    "value": "Имя пользователя MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Подсказка для поля имени пользователя MPS",
-    "value": "Имя пользователя MPS (по умолчанию: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Метка для поля пароля MPS",
-    "value": "Пароль MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Подсказка для поля пароля MPS",
-    "value": "Введите пароль MPS"
-  },
   "addDevice.amtPassword": {
     "description": "Метка для поля пароля AMT",
     "value": "Пароль AMT"

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -79,10 +79,6 @@
     "description": "Описание, объясняющее, как активировать устройство.",
     "value": "Для активации устройства необходимо выполнить команду на устройстве AMT. Это диалоговое окно поможет сгенерировать команду для запуска."
   },
-  "addDevice.enterGuid": {
-    "description": "Подсказка для ввода GUID",
-    "value": "Введите GUID"
-  },
   "addDevice.enterTags": {
     "description": "Подсказка для ввода тегов",
     "value": "Вы можете вводить теги, чтобы облегчить организацию и поиск устройств по мере роста списка управляемых устройств. Введите тег, затем нажмите Enter или запятую."
@@ -95,10 +91,6 @@
     "description": "Ошибка для обязательных дружественных имен",
     "value": "Требуется дружественное имя."
   },
-  "addDevice.guid": {
-    "description": "Метка для поля GUID",
-    "value": "GUID"
-  },
   "addDevice.hostNameInvalid": {
     "description": "Ошибка для недопустимых имен хостов",
     "value": "Неверный формат имени хоста"
@@ -106,22 +98,6 @@
   "addDevice.hostNameRequired": {
     "description": "Ошибка для обязательных имен хостов",
     "value": "Имя хоста является обязательным"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Метка для поля пароля MPS",
-    "value": "Пароль MPS"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Подсказка для поля пароля MPS",
-    "value": "Введите пароль MPS"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Метка для поля имени пользователя MPS",
-    "value": "Имя пользователя MPS"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Подсказка для поля имени пользователя MPS",
-    "value": "Имя пользователя MPS (по умолчанию: admin)"
   },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Флажок для отключения проверки самоподписанного сертификата.",
@@ -142,10 +118,6 @@
   "addDevice.title": {
     "description": "Заголовок диалогового окна для добавления нового устройства",
     "value": "Добавить новое устройство"
-  },
-  "addDevice.useCIRA": {
-    "description": "Флажок для использования соединения CIRA",
-    "value": "Использовать CIRA"
   },
   "addDevice.userNameInvalid": {
     "description": "Ошибка при вводе неверного имени пользователя",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -123,34 +123,6 @@
     "description": "Meddelande om användning av TLS",
     "value": "Använd TLS"
   },
-  "addDevice.useCIRA": {
-    "description": "Kryssruta för att använda CIRA-anslutning",
-    "value": "Använd CIRA"
-  },
-  "addDevice.guid": {
-    "description": "Etikett för GUID-fält",
-    "value": "GUID"
-  },
-  "addDevice.enterGuid": {
-    "description": "Tips för att ange GUID",
-    "value": "Ange GUID"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etikett för MPS-användarnamnsfält",
-    "value": "MPS-användarnamn"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Tips för MPS-användarnamnsfält",
-    "value": "MPS-användarnamn (standard: admin)"
-  },
-  "addDevice.mpsPassword": {
-    "description": "Etikett för MPS-lösenordsfält",
-    "value": "MPS-lösenord"
-  },
-  "addDevice.mpsPasswordHint": {
-    "description": "Tips för MPS-lösenordsfält",
-    "value": "Ange MPS-lösenord"
-  },
   "addDevice.amtPassword": {
     "description": "Etikett för AMT-lösenordsfält",
     "value": "AMT-lösenord"

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -55,38 +55,6 @@
     "description": "Etikett för MPS-lösenordsfält",
     "value": "MPS-lösenord"
   },
-  "addDevice.mpsPasswordHint": {
-    "description": "Tips för MPS-lösenordsfält",
-    "value": "Ange MPS-lösenord"
-  },
-  "addDevice.mpsUsername": {
-    "description": "Etikett för MPS-användarnamnsfält",
-    "value": "MPS-användarnamn"
-  },
-  "addDevice.mpsUsernameHint": {
-    "description": "Tips för MPS-användarnamnsfält",
-    "ider.status.checkingAMTFeatures": {
-      "description": "Statusmeddelande som visas när AMT-funktioner hämtas",
-      "value": "Hämtar AMT-funktioner..."
-    },
-    "ider.status.checkingConsent": {
-      "description": "Statusmeddelande som visas vid kontroll av användarens samtycke",
-      "value": "Kontrollerar samtyckesläge..."
-    },
-    "ider.status.checkingRedirection": {
-      "description": "Statusmeddelande som visas vid kontroll av omdirigeringsstatus",
-      "value": "Kontrollerar omdirigeringsstatus..."
-    },
-    "ider.status.connectingIder": {
-      "description": "Statusmeddelande som visas när IDER-komponenten ansluter",
-      "value": "Ansluter till IDER..."
-    },
-    "ider.stopIder.label": {
-      "description": "Knappetikett för att stoppa IDER-sessionen",
-      "value": "Stoppa IDER"
-    },
-    "value": "MPS-användarnamn (standard: admin)"
-  },
   "addDevice.noSelfSignedCertCheck": {
     "description": "Fel vid radering",
     "value": "Fel vid radering av larmhändelser"


### PR DESCRIPTION
Partially addresses https://github.com/device-management-toolkit/sample-web-ui/issues/3200https://github.com/device-management-toolkit/sample-web-ui/issues/3200https://github.com/device-management-toolkit/sample-web-ui/issues/3200 

Devices now connect to the stack automatically, so the manual CIRA toggle and its associated fields (GUID, MPS username, MPS password) are no longer needed.

<img width="637" height="588" alt="image" src="https://github.com/user-attachments/assets/61691e3d-53b0-40dc-9696-d85d12679d06" />


## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
