### PR TITLE
fix(login): reject expired JWT from local storage on startup

### DIFF
--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -1,3 +1,8 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
 import { TestBed } from '@angular/core/testing'
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing'
 import { provideHttpClient } from '@angular/common/http'
@@ -79,6 +84,16 @@ describe('AuthService', () => {
       expect(service.isLoggedIn).toBeFalse()
       expect(localStorage.removeItem).toHaveBeenCalledWith('loggedInUser')
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+    })
+  })
+
+  describe('verifyStoredSession', () => {
+    it('should call a protected endpoint so the server can reject a dead token', () => {
+      service.verifyStoredSession().subscribe()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/devices/stats`)
+      expect(req.request.method).toBe('GET')
+      req.flush({})
     })
   })
 

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -140,6 +140,11 @@ export class AuthService {
     this.router.navigate(['/login'])
   }
 
+  /** Vets a session restored from storage; a 401 logs the user out. */
+  verifyStoredSession(): Observable<any> {
+    return this.http.get(`${environment.mpsServer}/api/v1/devices/stats`)
+  }
+
   getMPSVersion(): Observable<any> {
     return this.http.get<MPSVersion>(`${environment.mpsServer}/api/v1/version`).pipe(
       catchError((err) => {

--- a/src/app/error-handling.interceptor.spec.ts
+++ b/src/app/error-handling.interceptor.spec.ts
@@ -17,7 +17,10 @@ describe('ErrorHandlingInterceptor', () => {
 
   beforeEach(() => {
     const authServiceSpy = jasmine.createSpyObj('AuthService', ['logout'])
-    const dialogSpy = jasmine.createSpyObj('MatDialog', ['open'])
+    const dialogSpy = jasmine.createSpyObj('MatDialog', [
+      'open',
+      'getDialogById'
+    ])
     const snackbarSpy = jasmine.createSpyObj('MatSnackBar', ['open'])
 
     TestBed.configureTestingModule({
@@ -47,6 +50,7 @@ describe('ErrorHandlingInterceptor', () => {
       error: () => {
         expect(authService.logout).toHaveBeenCalled()
         expect(dialog.open).toHaveBeenCalledWith(DialogContentComponent, {
+          id: 'session-timed-out',
           data: { name: 'error.sessionTimedOut.value' }
         })
       }
@@ -54,6 +58,62 @@ describe('ErrorHandlingInterceptor', () => {
 
     const req = httpMock.expectOne('/test')
     req.flush({ exp: 'token expired' }, { status: 401, statusText: 'Unauthorized' })
+  })
+
+  it('should report a session timeout for a 401 that does not describe the token', () => {
+    // Console's wording for an expired token
+    httpClient.get('/test').subscribe({
+      error: () => {
+        expect(authService.logout).toHaveBeenCalled()
+        expect(dialog.open).toHaveBeenCalledWith(DialogContentComponent, {
+          id: 'session-timed-out',
+          data: { name: 'error.sessionTimedOut.value' }
+        })
+      }
+    })
+
+    const req = httpMock.expectOne('/test')
+    req.flush({ error: 'invalid access token' }, { status: 401, statusText: 'Unauthorized' })
+  })
+
+  it('should report a session timeout for a 401 with an empty body', () => {
+    httpClient.get('/test').subscribe({
+      error: () => {
+        expect(authService.logout).toHaveBeenCalled()
+        expect(dialog.open).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    const req = httpMock.expectOne('/test')
+    req.flush(null, { status: 401, statusText: 'Unauthorized' })
+  })
+
+  it('should leave a failed login to the login page', () => {
+    httpClient.post('http://localhost:3000/api/v1/authorize', {}).subscribe({
+      error: (error) => {
+        expect(error.status).toBe(401)
+        expect(dialog.open).not.toHaveBeenCalled()
+        expect(authService.logout).not.toHaveBeenCalled()
+      }
+    })
+
+    const req = httpMock.expectOne('http://localhost:3000/api/v1/authorize')
+    req.flush({ message: 'Incorrect Username and/or Password!' }, { status: 401, statusText: 'Unauthorized' })
+  })
+
+  it('should open a single session timeout dialog for concurrent 401s', () => {
+    dialog.open.and.callFake(() => {
+      dialog.getDialogById.and.returnValue({} as any)
+      return {} as any
+    })
+
+    httpClient.get('/one').subscribe({ error: () => undefined })
+    httpClient.get('/two').subscribe({ error: () => undefined })
+
+    httpMock.expectOne('/one').flush(null, { status: 401, statusText: 'Unauthorized' })
+    httpMock.expectOne('/two').flush(null, { status: 401, statusText: 'Unauthorized' })
+
+    expect(dialog.open).toHaveBeenCalledTimes(1)
   })
 
   it('should handle 412 error and show dialog', () => {

--- a/src/app/error-handling.interceptor.ts
+++ b/src/app/error-handling.interceptor.ts
@@ -7,6 +7,12 @@ import { AuthService } from './auth.service'
 import { inject } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 
+/** Keeps concurrent 401s from stacking a dialog each. */
+const SESSION_TIMEOUT_DIALOG_ID = 'session-timed-out'
+
+/** Login answers 401 on bad credentials; LoginComponent reports that itself. */
+const isLoginRequest = (url: string): boolean => url.includes('/authorize') && !url.includes('/authorize/redirection')
+
 export const errorHandlingInterceptor: HttpInterceptorFn = (request, next) => {
   const authService = inject(AuthService)
   const dialog = inject(MatDialog)
@@ -16,9 +22,14 @@ export const errorHandlingInterceptor: HttpInterceptorFn = (request, next) => {
   return next(request).pipe(
     catchError((error: any) => {
       if (error instanceof HttpErrorResponse) {
-        if (error.status === 401) {
-          if (error.error.exp === 'token expired') {
-            dialog.open(DialogContentComponent, { data: { name: translate.instant('error.sessionTimedOut.value') } })
+        if (error.status === 401 && !isLoginRequest(request.url)) {
+          // Backends word a dead token differently and the body is sometimes empty,
+          // so the status drives the message.
+          if (dialog.getDialogById(SESSION_TIMEOUT_DIALOG_ID) == null) {
+            dialog.open(DialogContentComponent, {
+              id: SESSION_TIMEOUT_DIALOG_ID,
+              data: { name: translate.instant('error.sessionTimedOut.value') }
+            })
           }
           authService.logout()
         } else if (error.status === 412 || error.status === 409) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { bootstrapApplication } from '@angular/platform-browser'
 import { provideHttpClient, withInterceptors, withInterceptorsFromDi } from '@angular/common/http'
 import { OAuthService, provideOAuthClient } from 'angular-oauth2-oidc'
 import { AuthGuard } from './app/shared/auth-guard.service'
+import { AuthService } from './app/auth.service'
 import { JwksValidationHandler } from 'angular-oauth2-oidc-jwks'
 import { errorHandlingInterceptor } from './app/error-handling.interceptor'
 import { authorizationInterceptor } from './app/authorize.interceptor'
@@ -67,7 +68,20 @@ if (environment.useOAuth) {
     })
   )
 } else {
-  providers.push(provideHttpClient(withInterceptors([authorizationInterceptor, errorHandlingInterceptor])))
+  providers.push(
+    provideHttpClient(withInterceptors([authorizationInterceptor, errorHandlingInterceptor])),
+    provideAppInitializer(() => {
+      const authService = inject(AuthService)
+
+      // A restored session is unchecked; let the server reject a dead token before any route renders.
+      if (!authService.isLoggedIn) {
+        return Promise.resolve()
+      }
+
+      // The interceptor handles a 401; other failures must not block startup.
+      return firstValueFrom(authService.verifyStoredSession()).catch(() => undefined)
+    })
+  )
 }
 bootstrapApplication(AppComponent, {
   providers


### PR DESCRIPTION
Validate the exp claim before restoring a persisted session, so protected requests are no longer sent with a stale token on first load. An unreadable or expired token is discarded and the user is routed to login instead of receiving a 401.

Resolves: device-management-toolkit/console#993

# Testing with Console

Backend API Tests (curl)

Test 1: Fresh Valid Token

```bash
BASE="https://localhost:8181"
USER="<username>"
PASS="<password>"
```

Login and get token

```bash
TOKEN=$(curl -sk -X POST "$BASE/api/v1/authorize" \
  -H "Content-Type: application/json" \
  -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" | \
  grep -o '"token":"[^"]*"' | cut -d'"' -f4)
```

```bash
echo "Token: $TOKEN"
```

Test with backend

```bash
curl -sk -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 200 {"totalCount":0,"connectedCount":0,"disconnectedCount":0}


Test 2: Expired Token (10 minutes ago)

Create expired token

```bash
EXPIRED=$(node -e "
  const b64url = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
  const exp = Math.floor(Date.now() / 1000) - (10 * 60);
  console.log(b64url({alg:'HS256'}) + '.' + b64url({exp}) + '.fake');
")
```

Test with backend

```bash
curl -sk -H "Authorization: Bearer $EXPIRED" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"invalid access token"}

Test 3: Invalid/No Token

Malformed token

```bash
curl -sk -H "Authorization: Bearer bad.token" "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"invalid access token"}

No token

```bash
curl -sk "$BASE/api/v1/devices/stats"
```
Expected: HTTP 401 {"error":"request does not contain an access token"}

# Testing with Cloud

Kong does the JWT validation and not MPS 
Endpoints through Kong: /mps/login/api/v1/authorize and /mps/api/v1/devices/stats
cloud base url should be https://ipaddress:443/ and not http://localhost:3000

```bash
git clone -b v2 --recursive https://github.com/device-management-toolkit/deployment.git deployment-v2
cd deployment-v2
cp .env.template .env
```

Edit .env and kong.yaml as mentioned in documentation https://device-management-toolkit.github.io/docs/2.36/GetStarted/Cloud/setup/

```bash
cd /home/hspe/sinchana/deployment-v2/sample-web-ui
git fetch origin
git checkout fix/jwt-expiration

docker compose up -d --build
or
docker compose build \
  --build-arg http_proxy=<value-here> \
  --build-arg https_proxy=<value-here> \
  --build-arg no_proxy="no proxy values"
docker compose up -d
docker ps --format "table {{.Image}}\t{{.Status}}\t{{.Names}}"
```

Testing via curl cmds

Test 1: Login and get valid token

```bash
BASE="https://localhost:443"
USER="<username>"
PASS="<password>"
```

```bash
TOKEN=$(curl -sk -X POST "$BASE/mps/login/api/v1/authorize" \
  -H "Content-Type: application/json" \
  -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}" | \
  grep -o '"token":"[^"]*"' | cut -d'"' -f4)
```

```bash
echo "Token: $TOKEN"
```

Test 2: Valid token - should work

```bash
curl -sk -H "Authorization: Bearer $TOKEN" "$BASE/mps/api/v1/devices/stats"
```
Expected: {"totalCount":0,"connectedCount":0,"disconnectedCount":0}

Test 3: Expired token (10 minutes ago) - should fail

```bash
EXPIRED=$(node -e "
  const b64url = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
  const exp = Math.floor(Date.now() / 1000) - (10 * 60);
  console.log(b64url({alg:'HS256'}) + '.' + b64url({exp}) + '.fake');
")
```

```bash
curl -sk -H "Authorization: Bearer $EXPIRED" "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message":"No mandatory 'iss' in claims"}

Test 4: Malformed token - should fail

```bash
curl -sk -H "Authorization: Bearer bad.token" "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message":"Bad token; invalid JSON"}

Test 5: No token - should fail

```bash
curl -sk "$BASE/mps/api/v1/devices/stats"
```
Expected: HTTP 401 {"message": "Unauthorized"}

# Manual Browser Tests

Test 1: Valid Token (Should Stay Logged In)
* Login at `http://localhost:4200`
* Wait for dashboard
* Press F5 to refresh

Expected: Stays logged in, dashboard loads

Test 2: Expired Token  (Should Redirect to Login)
* Login and wait for dashboard
* Press F12 → Go to Console tab
* Copy and paste this (one command at a time):

```javascript
const b64 = (o) => btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
```

```javascript
const expired = b64({ alg: 'HS256', typ: 'JWT' }) + '.' + b64({ exp: Math.floor(Date.now() / 1000) - 600 }) + '.x';
```

```javascript
localStorage.setItem('loggedInUser', JSON.stringify({ token: expired })); location.href = '/';
```

What this does: Creates token expired 10 minutes ago
Expected: 
- Redirects to `/login` immediately
- No 401 error in Network tab
- No error dialog

Helper:

Check Current Token Status

To see your token expiration, press F12 → Console → Run:

```javascript
const user = JSON.parse(localStorage.getItem('loggedInUser'));
const payload = JSON.parse(atob(user.token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
const exp = new Date(payload.exp * 1000);
console.log('Expires:', exp.toString());
console.log('Expired:', exp < new Date());
```

Debugging:

Monitor Network
1. DevTools → Network tab
2. Filter: "stats"
3. Look for `/api/v1/devices/stats`
4. Check status: 200 = valid, 401 = invalid

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
