### PR TITLE
feat(login): use HttpOnly session cookie instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ The Sample Web UI provides a reference UI solution to help demonstrate the core 
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
+### Backend CORS settings for the session cookie
+
+The UI authenticates with an HttpOnly session cookie, so every API request is sent with `withCredentials: true`. A browser discards a credentialed response whose `Access-Control-Allow-Origin` is the `*` wildcard, which means the backend has to name the UI origin explicitly and allow credentials. There is no dev proxy, so this applies to every local setup: the UI is served from `http://localhost:4200` while the backend listens on a different port.
+
+For the Console/enterprise build (`npm run enterprise`, backend on `:8181`), set on the Console side:
+
+```
+HTTP_ALLOWED_ORIGINS=http://localhost:4200
+HTTP_ALLOW_CREDENTIALS=true
+```
+
+Console defaults to `AllowedOrigins: ["*"]` with `AllowCredentials: false`, so both values are required — otherwise every API call fails CORS and the login request never stores its cookie.
+
+Deployments that serve the UI from the same origin as the API need no CORS changes.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -1,3 +1,8 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2022
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
 import { TestBed } from '@angular/core/testing'
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing'
 import { provideHttpClient } from '@angular/common/http'
@@ -15,6 +20,9 @@ describe('AuthService', () => {
   const mockEnvironment = { mpsServer: 'https://test-mps', rpsServer: 'https://test-rps' }
 
   beforeEach(() => {
+    // The constructor reads the session flag, and spec order is random, so a
+    // leftover flag makes the suite fail intermittently.
+    localStorage.clear()
     routerSpy = jasmine.createSpyObj('Router', ['navigate'])
     environment.mpsServer = mockEnvironment.mpsServer
     environment.rpsServer = mockEnvironment.rpsServer
@@ -35,25 +43,58 @@ describe('AuthService', () => {
 
   afterEach(() => {
     httpMock.verify()
+    localStorage.clear()
   })
 
   it('should be created', () => {
     expect(service).toBeTruthy()
   })
 
+  describe('session flag on start-up', () => {
+    // Only the exact value login() writes counts as a session.
+    const cases = [
+      { flag: 'true', expected: true },
+      { flag: 'false', expected: false },
+      { flag: '1', expected: false },
+      { flag: '', expected: false }
+    ]
+
+    cases.forEach(({ flag, expected }) => {
+      it(`treats sessionActive="${flag}" as loggedIn=${expected}`, () => {
+        localStorage.setItem('sessionActive', flag)
+        TestBed.resetTestingModule()
+        TestBed.configureTestingModule({
+          providers: [
+            provideTranslateService(),
+            AuthService,
+            { provide: Router, useValue: routerSpy },
+            provideHttpClient(),
+            provideHttpClientTesting()
+          ]
+        })
+
+        expect(TestBed.inject(AuthService).isLoggedIn).toBe(expected)
+        httpMock = TestBed.inject(HttpTestingController)
+      })
+    })
+  })
+
   describe('login', () => {
-    it('should log in a user and update state', () => {
+    it('should log in a user and update state without persisting the token', () => {
       const mockResponse = { token: 'test-token' }
 
       service.login('testUser', 'testPass').subscribe(() => {
         expect(service.isLoggedIn).toBeTrue()
-        expect(localStorage.getItem('loggedInUser')).toBe(JSON.stringify(mockResponse))
+        expect(localStorage.getItem('sessionActive')).toBe('true')
       })
 
       const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize`)
       expect(req.request.method).toBe('POST')
       expect(req.request.body).toEqual({ username: 'testUser', password: 'testPass' })
       req.flush(mockResponse)
+
+      // Nothing readable may hold the session.
+      expect(JSON.stringify(localStorage)).not.toContain('test-token')
     })
 
     it('should handle errors', () => {
@@ -71,13 +112,38 @@ describe('AuthService', () => {
   })
 
   describe('logout', () => {
-    it('should log out the user and navigate to login', () => {
+    it('should clear session state and navigate to login', () => {
       spyOn(localStorage, 'removeItem')
 
       service.logout()
 
       expect(service.isLoggedIn).toBeFalse()
+      expect(localStorage.removeItem).toHaveBeenCalledWith('sessionActive')
       expect(localStorage.removeItem).toHaveBeenCalledWith('loggedInUser')
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+    })
+
+    it('should ask the server to expire the cookie when a session was active', () => {
+      service.isLoggedIn = true
+
+      service.logout()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
+      expect(req.request.method).toBe('POST')
+      req.flush({ message: 'logged out' })
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+    })
+
+    it('should still log out locally when the server call fails', () => {
+      service.isLoggedIn = true
+
+      service.logout()
+
+      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
+      req.flush(null, { status: 500, statusText: 'Server Error' })
+
+      expect(service.isLoggedIn).toBeFalse()
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
     })
   })

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -12,6 +12,12 @@ import { Router } from '@angular/router'
 import { ValidatorError, MPSVersion, RPSVersion } from '../models/models'
 import { OAuthService } from 'angular-oauth2-oidc'
 
+// A UI hint, not a credential. The session is an HttpOnly cookie.
+const SESSION_FLAG = 'sessionActive'
+
+// Held the JWT before the cookie migration. Purged on start-up.
+const LEGACY_TOKEN_KEY = 'loggedInUser'
+
 @Injectable({
   providedIn: 'root'
 })
@@ -32,7 +38,9 @@ export class AuthService {
     if (environment.useOAuth) {
       this.oauthService = inject(OAuthService)
     }
-    if (localStorage.loggedInUser != null) {
+    localStorage.removeItem(LEGACY_TOKEN_KEY)
+    // Match what login() writes, and only in the mode that writes it.
+    if (!environment.useOAuth && localStorage.getItem(SESSION_FLAG) === 'true') {
       this.isLoggedIn = true
       this.loggedInSubject$.next(this.isLoggedIn)
     }
@@ -105,21 +113,13 @@ export class AuthService {
       })
   }
 
-  getLoggedUserToken(): string {
-    const loggedInUser: string = localStorage.getItem('loggedInUser') ?? ''
-    if (loggedInUser !== '') {
-      const token: string = JSON.parse(loggedInUser).token
-      return token
-    }
-    return ''
-  }
-
   login(username: string, password: string): Observable<any> {
     return this.http.post<any>(this.url, { username, password }).pipe(
       map((data: any) => {
         if (!environment.useOAuth) {
+          // The body token is for REST clients; the browser uses the cookie.
           this.isLoggedIn = true
-          localStorage.loggedInUser = JSON.stringify(data)
+          localStorage.setItem(SESSION_FLAG, 'true')
           this.loggedInSubject$.next(this.isLoggedIn)
         }
         return data
@@ -131,12 +131,20 @@ export class AuthService {
   }
 
   logout(): void {
+    const hadSession = this.isLoggedIn
+
     this.isLoggedIn = false
     this.loggedInSubject$.next(this.isLoggedIn)
-    localStorage.removeItem('loggedInUser')
+    localStorage.removeItem(SESSION_FLAG)
+    localStorage.removeItem(LEGACY_TOKEN_KEY)
+
     if (environment.useOAuth) {
       this.oauthService?.logOut()
+    } else if (hadSession) {
+      // Only the server can expire an HttpOnly cookie. Fire and forget.
+      this.http.post(`${this.url}/logout`, {}).subscribe({ error: () => undefined })
     }
+
     this.router.navigate(['/login'])
   }
 

--- a/src/app/authorize.interceptor.spec.ts
+++ b/src/app/authorize.interceptor.spec.ts
@@ -18,7 +18,7 @@ describe('AuthorizeInterceptor', () => {
   let dialogSpy: jasmine.SpyObj<MatDialog>
 
   beforeEach(() => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['getLoggedUserToken', 'logout'])
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['logout'])
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open'])
 
     TestBed.configureTestingModule({
@@ -39,25 +39,29 @@ describe('AuthorizeInterceptor', () => {
     httpTestingController.verify()
   })
 
-  it('should add Authorization header if not calling /authorize', () => {
-    authServiceSpy.getLoggedUserToken.and.returnValue('test-token')
-
+  it('should send credentials so the session cookie travels with the request', () => {
     httpClient.get('/test').subscribe()
 
     const req = httpTestingController.expectOne('/test')
-    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token')
+    expect(req.request.withCredentials).toBeTrue()
   })
 
-  it('should not add Authorization header for /authorize endpoint', () => {
-    httpClient.get('/authorize').subscribe()
+  it('should never attach an Authorization header', () => {
+    httpClient.get('/test').subscribe()
+
+    const req = httpTestingController.expectOne('/test')
+    expect(req.request.headers.has('Authorization')).toBeFalse()
+  })
+
+  it('should send credentials on /authorize so the cookie is stored', () => {
+    httpClient.post('/authorize', { username: 'u', password: 'p' }).subscribe()
 
     const req = httpTestingController.expectOne('/authorize')
+    expect(req.request.withCredentials).toBeTrue()
     expect(req.request.headers.has('Authorization')).toBeFalse()
   })
 
   it('should add if-match header if body contains version', () => {
-    authServiceSpy.getLoggedUserToken.and.returnValue('test-token')
-
     httpClient.post('/test', { version: '123' }).subscribe()
 
     const req = httpTestingController.expectOne('/test')

--- a/src/app/authorize.interceptor.ts
+++ b/src/app/authorize.interceptor.ts
@@ -3,28 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
-import { inject } from '@angular/core'
 import { HttpInterceptorFn } from '@angular/common/http'
-import { AuthService } from './auth.service'
 
 export const authorizationInterceptor: HttpInterceptorFn = (request, next) => {
-  const authService = inject(AuthService)
-
-  if (request.url.toString().includes('/authorize') && !request.url.toString().includes('/authorize/redirection')) {
-    // Skip adding authorization headers for specific routes
-    return next(request)
-  }
-
-  const headers: any = {
-    Authorization: `Bearer ${authService.getLoggedUserToken()}`
-  }
+  const headers: any = {}
 
   if ((request.body as any)?.version != null && (request.body as any)?.version !== '') {
     headers['if-match'] = (request.body as any).version
   }
 
+  // No token to attach: the session is an HttpOnly cookie. withCredentials lets
+  // the browser store and send it across origins, login request included.
   request = request.clone({
-    setHeaders: headers
+    setHeaders: headers,
+    withCredentials: true
   })
 
   return next(request)


### PR DESCRIPTION
The session JWT was persisted in localStorage under `loggedInUser`, leaving it readable by any script running on the page. Console now issues the same token as an HttpOnly cookie, so the browser no longer needs its own copy.

- drop the Authorization header from the interceptor and send withCredentials instead, so the cookie is stored and returned; it is needed on the login request too, or a cross-origin Set-Cookie is discarded
- replace the stored token with a `sessionActive` flag, which is a UI hint rather than a credential
- purge the legacy `loggedInUser` key on start-up so upgrading does not leave a usable token sitting on disk
- call POST /api/v1/authorize/logout, since only the server can expire an HttpOnly cookie

Not a breaking change. Release binaries embed this UI, so Console and the UI ship as one artifact and cannot drift apart. Headless deployments are unaffected: REST clients keep authenticating with the Authorization header, which still takes precedence. Only local development, where the UI is served separately on :4200, needs both sides moved together.

The KVM/SOL/IDER redirection token is deliberately untouched: it is already short-lived and held in memory, and it must stay readable by script because it travels in the Sec-WebSocket-Protocol header.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
