### PR TITLE
fix(login): keep bearer auth for cloud builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app w
 
 ### Backend CORS settings for the session cookie
 
-The UI authenticates with an HttpOnly session cookie, so every API request is sent with `withCredentials: true`. A browser discards a credentialed response whose `Access-Control-Allow-Origin` is the `*` wildcard, which means the backend has to name the UI origin explicitly and allow credentials. There is no dev proxy, so this applies to every local setup: the UI is served from `http://localhost:4200` while the backend listens on a different port.
+The two builds carry the session differently. The cloud build (`npm start`) authenticates against MPS and RPS with an `Authorization: Bearer` header, because Kong verifies the JWT itself and reads it only from that header. It sends no credentials, so nothing below applies to it.
+
+The Console/enterprise build authenticates with an HttpOnly session cookie, so every API request is sent with `withCredentials: true`. A browser discards a credentialed response whose `Access-Control-Allow-Origin` is the `*` wildcard, which means the backend has to name the UI origin explicitly and allow credentials. There is no dev proxy, so this applies to every local setup: the UI is served from `http://localhost:4200` while the backend listens on a different port.
 
 For the Console/enterprise build (`npm run enterprise`, backend on `:8181`), set on the Console side:
 

--- a/src/app/auth.service.spec.ts
+++ b/src/app/auth.service.spec.ts
@@ -18,6 +18,7 @@ describe('AuthService', () => {
   let routerSpy: jasmine.SpyObj<Router>
 
   const mockEnvironment = { mpsServer: 'https://test-mps', rpsServer: 'https://test-rps' }
+  const originalCloud = environment.cloud
 
   beforeEach(() => {
     // The constructor reads the session flag, and spec order is random, so a
@@ -44,59 +45,97 @@ describe('AuthService', () => {
   afterEach(() => {
     httpMock.verify()
     localStorage.clear()
+    environment.cloud = originalCloud
   })
 
   it('should be created', () => {
     expect(service).toBeTruthy()
   })
 
-  describe('session flag on start-up', () => {
-    // Only the exact value login() writes counts as a session.
-    const cases = [
-      { flag: 'true', expected: true },
-      { flag: 'false', expected: false },
-      { flag: '1', expected: false },
-      { flag: '', expected: false }
-    ]
+  describe('session restore on start-up', () => {
+    const rebuild = (): AuthService => {
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideTranslateService(),
+          AuthService,
+          { provide: Router, useValue: routerSpy },
+          provideHttpClient(),
+          provideHttpClientTesting()
+        ]
+      })
 
-    cases.forEach(({ flag, expected }) => {
-      it(`treats sessionActive="${flag}" as loggedIn=${expected}`, () => {
-        localStorage.setItem('sessionActive', flag)
-        TestBed.resetTestingModule()
-        TestBed.configureTestingModule({
-          providers: [
-            provideTranslateService(),
-            AuthService,
-            { provide: Router, useValue: routerSpy },
-            provideHttpClient(),
-            provideHttpClientTesting()
-          ]
+      const rebuilt = TestBed.inject(AuthService)
+      httpMock = TestBed.inject(HttpTestingController)
+      return rebuilt
+    }
+
+    describe('enterprise', () => {
+      beforeEach(() => {
+        environment.cloud = false
+      })
+
+      // Only the exact value login() writes counts as a session.
+      const cases = [
+        { flag: 'true', expected: true },
+        { flag: 'false', expected: false },
+        { flag: '1', expected: false },
+        { flag: '', expected: false }
+      ]
+
+      cases.forEach(({ flag, expected }) => {
+        it(`treats sessionActive="${flag}" as loggedIn=${expected}`, () => {
+          localStorage.setItem('sessionActive', flag)
+
+          expect(rebuild().isLoggedIn).toBe(expected)
         })
+      })
 
-        expect(TestBed.inject(AuthService).isLoggedIn).toBe(expected)
-        httpMock = TestBed.inject(HttpTestingController)
+      it('should purge a token left over from before the cookie migration', () => {
+        localStorage.setItem('loggedInUser', JSON.stringify({ token: 'stale-token' }))
+
+        rebuild()
+
+        expect(localStorage.getItem('loggedInUser')).toBeNull()
+      })
+    })
+
+    describe('cloud', () => {
+      beforeEach(() => {
+        environment.cloud = true
+      })
+
+      it('should restore the session from the stored token', () => {
+        localStorage.setItem('loggedInUser', JSON.stringify({ token: 'test-token' }))
+
+        expect(rebuild().isLoggedIn).toBeTrue()
+      })
+
+      it('should keep the token, which the Authorization header needs', () => {
+        localStorage.setItem('loggedInUser', JSON.stringify({ token: 'test-token' }))
+
+        expect(rebuild().getLoggedUserToken()).toBe('test-token')
+      })
+
+      it('should not restore a session from a corrupt token', () => {
+        localStorage.setItem('loggedInUser', 'not-json')
+
+        expect(rebuild().isLoggedIn).toBeFalse()
+      })
+
+      it('should not restore a session when the stored value has no token', () => {
+        localStorage.setItem('loggedInUser', JSON.stringify({ user: 'admin' }))
+
+        expect(rebuild().isLoggedIn).toBeFalse()
+      })
+
+      it('should not restore a session when no token is stored', () => {
+        expect(rebuild().isLoggedIn).toBeFalse()
       })
     })
   })
 
   describe('login', () => {
-    it('should log in a user and update state without persisting the token', () => {
-      const mockResponse = { token: 'test-token' }
-
-      service.login('testUser', 'testPass').subscribe(() => {
-        expect(service.isLoggedIn).toBeTrue()
-        expect(localStorage.getItem('sessionActive')).toBe('true')
-      })
-
-      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize`)
-      expect(req.request.method).toBe('POST')
-      expect(req.request.body).toEqual({ username: 'testUser', password: 'testPass' })
-      req.flush(mockResponse)
-
-      // Nothing readable may hold the session.
-      expect(JSON.stringify(localStorage)).not.toContain('test-token')
-    })
-
     it('should handle errors', () => {
       const mockError = { status: 401, statusText: 'Unauthorized' }
 
@@ -108,6 +147,49 @@ describe('AuthService', () => {
 
       const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize`)
       req.flush(null, mockError)
+    })
+
+    describe('enterprise', () => {
+      beforeEach(() => {
+        environment.cloud = false
+      })
+
+      it('should log in a user and update state without persisting the token', () => {
+        const mockResponse = { token: 'test-token' }
+
+        service.login('testUser', 'testPass').subscribe(() => {
+          expect(service.isLoggedIn).toBeTrue()
+          expect(localStorage.getItem('sessionActive')).toBe('true')
+        })
+
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize`)
+        expect(req.request.method).toBe('POST')
+        expect(req.request.body).toEqual({ username: 'testUser', password: 'testPass' })
+        req.flush(mockResponse)
+
+        // Nothing readable may hold the session.
+        expect(JSON.stringify(localStorage)).not.toContain('test-token')
+      })
+    })
+
+    describe('cloud', () => {
+      beforeEach(() => {
+        environment.cloud = true
+      })
+
+      it('should persist the token, since Kong reads the Authorization header', () => {
+        const mockResponse = { token: 'test-token' }
+
+        service.login('testUser', 'testPass').subscribe(() => {
+          expect(service.isLoggedIn).toBeTrue()
+          expect(service.getLoggedUserToken()).toBe('test-token')
+          expect(localStorage.getItem('sessionActive')).toBeNull()
+        })
+
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize`)
+        expect(req.request.method).toBe('POST')
+        req.flush(mockResponse)
+      })
     })
   })
 
@@ -123,28 +205,51 @@ describe('AuthService', () => {
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
     })
 
-    it('should ask the server to expire the cookie when a session was active', () => {
-      service.isLoggedIn = true
+    describe('enterprise', () => {
+      beforeEach(() => {
+        environment.cloud = false
+      })
 
-      service.logout()
+      it('should ask the server to expire the cookie when a session was active', () => {
+        service.isLoggedIn = true
 
-      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
-      expect(req.request.method).toBe('POST')
-      req.flush({ message: 'logged out' })
+        service.logout()
 
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
+        expect(req.request.method).toBe('POST')
+        req.flush({ message: 'logged out' })
+
+        expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+      })
+
+      it('should still log out locally when the server call fails', () => {
+        service.isLoggedIn = true
+
+        service.logout()
+
+        const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
+        req.flush(null, { status: 500, statusText: 'Server Error' })
+
+        expect(service.isLoggedIn).toBeFalse()
+        expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+      })
     })
 
-    it('should still log out locally when the server call fails', () => {
-      service.isLoggedIn = true
+    describe('cloud', () => {
+      beforeEach(() => {
+        environment.cloud = true
+      })
 
-      service.logout()
+      it('should not call a logout route, since MPS has none', () => {
+        service.isLoggedIn = true
 
-      const req = httpMock.expectOne(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
-      req.flush(null, { status: 500, statusText: 'Server Error' })
+        service.logout()
 
-      expect(service.isLoggedIn).toBeFalse()
-      expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+        httpMock.expectNone(`${mockEnvironment.mpsServer}/api/v1/authorize/logout`)
+        expect(service.isLoggedIn).toBeFalse()
+        expect(localStorage.getItem('loggedInUser')).toBeNull()
+        expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'])
+      })
     })
   })
 

--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -12,11 +12,11 @@ import { Router } from '@angular/router'
 import { ValidatorError, MPSVersion, RPSVersion } from '../models/models'
 import { OAuthService } from 'angular-oauth2-oidc'
 
-// A UI hint, not a credential. The session is an HttpOnly cookie.
+// A UI hint, not a credential. The Console binary's session is an HttpOnly cookie.
 const SESSION_FLAG = 'sessionActive'
 
-// Held the JWT before the cookie migration. Purged on start-up.
-const LEGACY_TOKEN_KEY = 'loggedInUser'
+// The session JWT. Cloud sends it; the Console binary purges it.
+const TOKEN_KEY = 'loggedInUser'
 
 @Injectable({
   providedIn: 'root'
@@ -38,11 +38,18 @@ export class AuthService {
     if (environment.useOAuth) {
       this.oauthService = inject(OAuthService)
     }
-    localStorage.removeItem(LEGACY_TOKEN_KEY)
     // Match what login() writes, and only in the mode that writes it.
-    if (!environment.useOAuth && localStorage.getItem(SESSION_FLAG) === 'true') {
-      this.isLoggedIn = true
-      this.loggedInSubject$.next(this.isLoggedIn)
+    if (environment.cloud) {
+      if (!environment.useOAuth && this.getLoggedUserToken() !== '') {
+        this.isLoggedIn = true
+        this.loggedInSubject$.next(this.isLoggedIn)
+      }
+    } else {
+      localStorage.removeItem(TOKEN_KEY)
+      if (!environment.useOAuth && localStorage.getItem(SESSION_FLAG) === 'true') {
+        this.isLoggedIn = true
+        this.loggedInSubject$.next(this.isLoggedIn)
+      }
     }
     if (environment.mpsServer.includes('/mps')) {
       // handles kong route
@@ -113,13 +120,31 @@ export class AuthService {
       })
   }
 
+  getLoggedUserToken(): string {
+    const loggedInUser: string = localStorage.getItem(TOKEN_KEY) ?? ''
+    if (loggedInUser === '') {
+      return ''
+    }
+    try {
+      // The constructor calls this, so a corrupt value must not throw.
+      return JSON.parse(loggedInUser).token ?? ''
+    } catch {
+      return ''
+    }
+  }
+
   login(username: string, password: string): Observable<any> {
     return this.http.post<any>(this.url, { username, password }).pipe(
       map((data: any) => {
         if (!environment.useOAuth) {
-          // The body token is for REST clients; the browser uses the cookie.
           this.isLoggedIn = true
-          localStorage.setItem(SESSION_FLAG, 'true')
+          if (environment.cloud) {
+            // Kong verifies the JWT, so keep a copy to send.
+            localStorage.setItem(TOKEN_KEY, JSON.stringify(data))
+          } else {
+            // The body token is for REST clients; the browser uses the cookie.
+            localStorage.setItem(SESSION_FLAG, 'true')
+          }
           this.loggedInSubject$.next(this.isLoggedIn)
         }
         return data
@@ -136,12 +161,12 @@ export class AuthService {
     this.isLoggedIn = false
     this.loggedInSubject$.next(this.isLoggedIn)
     localStorage.removeItem(SESSION_FLAG)
-    localStorage.removeItem(LEGACY_TOKEN_KEY)
+    localStorage.removeItem(TOKEN_KEY)
 
     if (environment.useOAuth) {
       this.oauthService?.logOut()
-    } else if (hadSession) {
-      // Only the server can expire an HttpOnly cookie. Fire and forget.
+    } else if (!environment.cloud && hadSession) {
+      // Only the server can expire an HttpOnly cookie. MPS has no such route.
       this.http.post(`${this.url}/logout`, {}).subscribe({ error: () => undefined })
     }
 

--- a/src/app/authorize.interceptor.spec.ts
+++ b/src/app/authorize.interceptor.spec.ts
@@ -9,6 +9,7 @@ import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common
 import { MatDialog } from '@angular/material/dialog'
 import { authorizationInterceptor } from './authorize.interceptor'
 import { AuthService } from './auth.service'
+import { environment } from '../environments/environment'
 import { provideTranslateService } from '@ngx-translate/core'
 
 describe('AuthorizeInterceptor', () => {
@@ -16,9 +17,11 @@ describe('AuthorizeInterceptor', () => {
   let httpTestingController: HttpTestingController
   let authServiceSpy: jasmine.SpyObj<AuthService>
   let dialogSpy: jasmine.SpyObj<MatDialog>
+  const originalCloud = environment.cloud
 
   beforeEach(() => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['logout'])
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['logout', 'getLoggedUserToken'])
+    authServiceSpy.getLoggedUserToken.and.returnValue('a-token')
     dialogSpy = jasmine.createSpyObj('MatDialog', ['open'])
 
     TestBed.configureTestingModule({
@@ -37,28 +40,7 @@ describe('AuthorizeInterceptor', () => {
 
   afterEach(() => {
     httpTestingController.verify()
-  })
-
-  it('should send credentials so the session cookie travels with the request', () => {
-    httpClient.get('/test').subscribe()
-
-    const req = httpTestingController.expectOne('/test')
-    expect(req.request.withCredentials).toBeTrue()
-  })
-
-  it('should never attach an Authorization header', () => {
-    httpClient.get('/test').subscribe()
-
-    const req = httpTestingController.expectOne('/test')
-    expect(req.request.headers.has('Authorization')).toBeFalse()
-  })
-
-  it('should send credentials on /authorize so the cookie is stored', () => {
-    httpClient.post('/authorize', { username: 'u', password: 'p' }).subscribe()
-
-    const req = httpTestingController.expectOne('/authorize')
-    expect(req.request.withCredentials).toBeTrue()
-    expect(req.request.headers.has('Authorization')).toBeFalse()
+    environment.cloud = originalCloud
   })
 
   it('should add if-match header if body contains version', () => {
@@ -66,5 +48,61 @@ describe('AuthorizeInterceptor', () => {
 
     const req = httpTestingController.expectOne('/test')
     expect(req.request.headers.get('if-match')).toBe('123')
+  })
+
+  describe('cloud', () => {
+    beforeEach(() => {
+      environment.cloud = true
+    })
+
+    it('should attach the bearer token Kong expects', () => {
+      httpClient.get('/test').subscribe()
+
+      const req = httpTestingController.expectOne('/test')
+      expect(req.request.headers.get('Authorization')).toBe('Bearer a-token')
+      expect(req.request.withCredentials).toBeFalse()
+    })
+
+    it('should skip the token on /authorize, since login is unauthenticated', () => {
+      httpClient.post('/authorize', { username: 'u', password: 'p' }).subscribe()
+
+      const req = httpTestingController.expectOne('/authorize')
+      expect(req.request.headers.has('Authorization')).toBeFalse()
+    })
+
+    it('should attach the token on /authorize/redirection, which Kong guards', () => {
+      httpClient.get('/authorize/redirection/guid').subscribe()
+
+      const req = httpTestingController.expectOne('/authorize/redirection/guid')
+      expect(req.request.headers.get('Authorization')).toBe('Bearer a-token')
+    })
+  })
+
+  describe('enterprise', () => {
+    beforeEach(() => {
+      environment.cloud = false
+    })
+
+    it('should send credentials so the session cookie travels with the request', () => {
+      httpClient.get('/test').subscribe()
+
+      const req = httpTestingController.expectOne('/test')
+      expect(req.request.withCredentials).toBeTrue()
+    })
+
+    it('should never attach an Authorization header', () => {
+      httpClient.get('/test').subscribe()
+
+      const req = httpTestingController.expectOne('/test')
+      expect(req.request.headers.has('Authorization')).toBeFalse()
+    })
+
+    it('should send credentials on /authorize so the cookie is stored', () => {
+      httpClient.post('/authorize', { username: 'u', password: 'p' }).subscribe()
+
+      const req = httpTestingController.expectOne('/authorize')
+      expect(req.request.withCredentials).toBeTrue()
+      expect(req.request.headers.has('Authorization')).toBeFalse()
+    })
   })
 })

--- a/src/app/authorize.interceptor.ts
+++ b/src/app/authorize.interceptor.ts
@@ -3,20 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 
+import { inject } from '@angular/core'
 import { HttpInterceptorFn } from '@angular/common/http'
+import { environment } from '../environments/environment'
+import { AuthService } from './auth.service'
 
 export const authorizationInterceptor: HttpInterceptorFn = (request, next) => {
+  // Kong only reads the Authorization header. The Console binary uses a cookie.
+  const authService = environment.cloud ? inject(AuthService) : null
+
+  if (
+    authService != null &&
+    request.url.toString().includes('/authorize') &&
+    !request.url.toString().includes('/authorize/redirection')
+  ) {
+    // Skip adding authorization headers for specific routes
+    return next(request)
+  }
+
   const headers: any = {}
+
+  if (authService != null) {
+    const token = authService.getLoggedUserToken()
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
+  }
 
   if ((request.body as any)?.version != null && (request.body as any)?.version !== '') {
     headers['if-match'] = (request.body as any).version
   }
 
-  // No token to attach: the session is an HttpOnly cookie. withCredentials lets
-  // the browser store and send it across origins, login request included.
   request = request.clone({
     setHeaders: headers,
-    withCredentials: true
+    // Lets the Console binary's session cookie travel cross-origin.
+    withCredentials: !environment.cloud
   })
 
   return next(request)


### PR DESCRIPTION
PR #3499 moved the session to an HttpOnly cookie issued by the Console binary. Cloud builds reach MPS and RPS through Kong, whose jwt plugin only reads the Authorization header and never a cookie, so dropping the header left every request returning 401.

Branch the auth transport on environment.cloud, which already separates the two backends throughout the app:

- cloud restores the Authorization header, including on /authorize/redirection, which Kong guards and KVM/SOL depend on
- the Console binary keeps withCredentials and the sessionActive flag
- the start-up purge of loggedInUser is now Console-only; under cloud it deleted the token the next request needs
- the logout POST is Console-only, since MPS has no such route

Cloud keeps the JWT in localStorage until MPS issues the cookie and Kong is configured to read it.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
