### PR TITLE
fix(sol): consume Angular UTF-8 toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "~21.2.19",
         "@angular/platform-browser-dynamic": "~21.2.19",
         "@angular/router": "~21.2.19",
-        "@device-management-toolkit/ui-toolkit-angular": "^11.1.7",
+        "@device-management-toolkit/ui-toolkit-angular": "github:device-management-toolkit/ui-toolkit-angular#fix/sol-utf8-toolkit",
         "@ngx-translate/core": "^18.0.0",
         "@ngx-translate/http-loader": "^18.0.0",
         "@xterm/xterm": "^6.0.0",
@@ -3962,9 +3962,9 @@
       }
     },
     "node_modules/@device-management-toolkit/ui-toolkit": {
+      "name": "@open-amt-cloud-toolkit/ui-toolkit",
       "version": "3.3.19",
-      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit/-/ui-toolkit-3.3.19.tgz",
-      "integrity": "sha512-KTwfhwjZiYVxaTICyU4D+++Vdkt5HGUDCM8WEl3WwZheJ/ewoRguKxkfbHf7xONfYsAG2Od2cSHnx1usojofkA==",
+      "resolved": "git+ssh://git@github.com/device-management-toolkit/ui-toolkit.git#d108647",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -3974,14 +3974,13 @@
     },
     "node_modules/@device-management-toolkit/ui-toolkit-angular": {
       "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/@device-management-toolkit/ui-toolkit-angular/-/ui-toolkit-angular-11.1.7.tgz",
-      "integrity": "sha512-zWAD+9Vnqlrz+VM+UY16pCUudiX/IukHkaua2e9pBXbaM06TFIlkUpmApULSCo1RggfnQQHqh89Hx3ERqQj/aQ==",
+      "resolved": "git+ssh://git@github.com/device-management-toolkit/ui-toolkit-angular.git#978bcab",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@device-management-toolkit/ui-toolkit": "^3.3.19",
+        "@device-management-toolkit/ui-toolkit": "github:device-management-toolkit/ui-toolkit#fix/sol-utf8-decoding",
         "@xterm/xterm": "^6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "~21.2.19",
     "@angular/platform-browser-dynamic": "~21.2.19",
     "@angular/router": "~21.2.19",
-    "@device-management-toolkit/ui-toolkit-angular": "^11.1.7",
+    "@device-management-toolkit/ui-toolkit-angular": "github:device-management-toolkit/ui-toolkit-angular#fix/sol-utf8-toolkit",
     "@ngx-translate/core": "^18.0.0",
     "@ngx-translate/http-loader": "^18.0.0",
     "@xterm/xterm": "^6.0.0",


### PR DESCRIPTION
## Summary
- Consume the `ui-toolkit-angular` SOL UTF-8 feature branch.
- Lock the related Git branch resolutions for reproducible feature-branch builds.
- Keep the change limited to `package.json` and the required `package-lock.json` entries.

## Validation
- Clean `npm ci`
- `npm run build-enterprise`

For the local Console build, generate `ui-toolkit/core`, `ui-toolkit/bundles`, and `ui-toolkit-angular/dist` first, inject them into `node_modules`, build the enterprise UI, then run the Console script with `BUILD_UI=false`.

Depends on the `ui-toolkit` and `ui-toolkit-angular` SOL UTF-8 changes.