### PR TITLE
refactor(e2e): support delete multiple devices for console

### DIFF
--- a/cypress/e2e/integration/device/delete.spec.ts
+++ b/cypress/e2e/integration/device/delete.spec.ts
@@ -84,8 +84,9 @@ describeWhenNotCloud('Test Device Deletion', () => {
       body: empty.response
     }).as('get-devices-after-delete')
 
-    // Click delete and confirm
-    cy.get('mat-cell').contains('delete').click()
+    // Scope deletion to this device's row (matched by hostname/IP) so that
+    // multiple devices sharing the friendly name are not affected (ISOLATE=N).
+    cy.contains('mat-row', Cypress.env('DEVICE')).find('mat-cell').contains('delete').click()
     cy.get('button').contains('Yes').click()
 
     // Wait for delete and list refresh requests
@@ -94,8 +95,8 @@ describeWhenNotCloud('Test Device Deletion', () => {
     })
     cy.wait('@get-devices-after-delete').its('response.statusCode').should('eq', httpCodes.SUCCESS)
 
-    // Verify the device no longer appears in the list
+    // Only this device (matched by hostname/IP) must be gone; under ISOLATE=N other
+    // devices may still carry the shared 'Test Device' friendly name.
     cy.contains(Cypress.env('DEVICE')).should('not.exist')
-    cy.contains('Test Device').should('not.exist')
   })
 })


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?
Updated the console E2E delete-device test to support deleting multiple devices in a single flow.

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
