### PR TITLE
ci: bump security report action to v4.1.0 and surface its failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -84,18 +84,25 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
     - name: Generate Security Report
-      uses: rsdmike/github-security-report-action@1df22b1e0a7e15b32f728ccf7bab259e46c80589 # v4.0.1
-      continue-on-error: true
+      id: security_report
+      # SECURITY_TOKEN is not available to fork PRs or Dependabot runs; an empty token fails the step.
+      if: >-
+        github.actor != 'dependabot[bot]' &&
+        (github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository)
+      uses: rsdmike/github-security-report-action@a3d8cc051bc89f1b622d396adab901aa73857a29 # v4.1.0
       with:
         template: report
         token: ${{ secrets.SECURITY_TOKEN }}
     - name: Rename Report
+      if: steps.security_report.outcome == 'success'
       shell: bash
       continue-on-error: true
       run: |
         DATE=$(date +"%Y-%m-%d")
         mv "report.pdf" "sample-web-ui-security-report-$DATE.pdf"
     - name: GitHub Upload Release Artifacts
+      if: steps.security_report.outcome == 'success'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       continue-on-error: true
       with:


### PR DESCRIPTION
## Why

The **Generate Security Report** step in this workflow has been failing and producing no PDF:

```
##[error]Request failed due to following response errors:
 - timedout
mv: cannot stat 'report.pdf': No such file or directory
```

This was invisible because the step carries `continue-on-error: true` — the CodeQL job stayed green and GitHub's API reported the step's `conclusion` as `success`, since `continue-on-error` rewrites it. The failure existed only in the raw logs.

Root cause was in the action: it expanded `dependencyGraphManifests.dependencies` over GraphQL, which makes GitHub resolve every manifest's full dependency graph. A large lockfile exceeds the server-side budget and times out. Fixed in [rsdmike/github-security-report-action#274](https://github.com/rsdmike/github-security-report-action/pull/274), released as [v4.1.0](https://github.com/rsdmike/github-security-report-action/releases/tag/v4.1.0).

## Changes

- Bump `rsdmike/github-security-report-action` from v4.0.1 to **v4.1.0** (`a3d8cc0`, verified to match the `v4.1.0` tag).
- **Drop `continue-on-error: true`** from that step so failures fail the job.
- **Gate the step to non-fork events.** `SECURITY_TOKEN` is not exposed to fork PRs, and the action reads it via `core.getInput('token', { required: true })`, which throws `Input required and not supplied: token` on an empty value. Without the guard, removing the suppression would fail the whole CodeQL job on external contributions.

## Verification

This exact change was verified end to end in [ui-toolkit-angular#2578](https://github.com/device-management-toolkit/ui-toolkit-angular/pull/2578): the report step went from failing in 5.4s with no output, to succeeding in 12s and uploading a 132KB PDF artifact — with the guard confirmed **not** to skip the step on same-repo PRs.

The CodeQL run on this PR exercises it here.

## Notes

- `continue-on-error` is deliberately left on **Rename Report** and **Upload Artifacts**; those are unreachable if the report step fails now.
- I have not separately confirmed this repo's logs showed the same `timedout` error — the fix and the suppression removal are correct regardless, and this PR's own CodeQL run will demonstrate it.

https://claude.ai/code/session_017rtnF1RVUGPNwD6f7EL8cB