### PR TITLE
build(deps): Bump qs from 6.15.2 to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16254,13 +16254,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1",
     "webpack-dev-server": "^5.2.6",
-    "less": "^4.9.0"
+    "less": "^4.9.0",
+    "qs": "^6.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~21.2.23",


### PR DESCRIPTION
Bumps qs from 6.15.2 to 6.16.0.

Advisory: GHSA-x5fp-wj9c-mxmx (medium), GHSA-4mjr-xmp4-gh2g (medium)
Dependency: transitive via express (webpack-dev-server, @modelcontextprotocol/sdk) and @cypress/request; pinned with an npm overrides entry
Build/test: pass on fix/deps-qs-6.16.0
