### PR TITLE
ci(gh-actions): bump Node from 20.x to 26.x

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [26.x]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [26.x]
 
     steps:
       - name: Harden Runner
@@ -35,16 +35,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run lint
-        if: ${{ matrix.node-version == '22.x' }}
       - run: npm run lint:cypress
-        if: ${{ matrix.node-version == '22.x' }}
       - run: npm run ci-prettify
       - run: npm run test-ci -- --output-file=sample-web-ui-$NODE_VERSION.xml
         env:
           NODE_VERSION: ${{ matrix.node-version }}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         name: Upload Coverage Results
-        if: ${{ matrix.node-version == '22.x' }}
         with:
           directory: ./coverage/samplewebui
       - name: Upload Test Results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Use Node.js 20.x
+      - name: Use Node.js 26.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20.x'
+          node-version: '26.x'
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - run: npm ci


### PR DESCRIPTION
Moves all three CI workflows from Node 20.x / 22.x onto **26.x**, Node 20 reached **end of life on 2026-04-30**, and Cypress 16 supports Node 22.x, 24.x, and 26.x and above.